### PR TITLE
Release: V3.1.1

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,6 @@
 [target.x86_64-unknown-linux-gnu]
 linker = "/usr/bin/clang"
-rustflags = ["-Clink-arg=-fuse-ld=lld"]
+rustflags = ["-Clink-arg=-fuse-ld=lld", "-Zshare-generics=y"]
 
 [target.x86_64-apple-darwin]
 rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/zld"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1697,7 +1697,7 @@ dependencies = [
 
 [[package]]
 name = "roblox"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "hyper",
  "hyper-rustls",
@@ -1711,7 +1711,7 @@ dependencies = [
 
 [[package]]
 name = "rowifi"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "base64",
  "chacha20poly1305",
@@ -1748,7 +1748,7 @@ dependencies = [
 
 [[package]]
 name = "rowifi-cache"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "dashmap",
  "rowifi-models",
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "rowifi-database"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "futures-util",
  "mongodb",
@@ -1768,7 +1768,7 @@ dependencies = [
 
 [[package]]
 name = "rowifi-framework"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "chacha20poly1305",
  "chrono",
@@ -1796,7 +1796,7 @@ dependencies = [
 
 [[package]]
 name = "rowifi-models"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "itertools",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1740,11 +1740,8 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-subscriber",
- "twilight-embed-builder",
  "twilight-gateway",
  "twilight-http",
- "twilight-mention",
- "twilight-model",
  "twilight-standby",
 ]
 
@@ -1755,7 +1752,6 @@ dependencies = [
  "dashmap",
  "rowifi-models",
  "tracing",
- "twilight-model",
 ]
 
 [[package]]
@@ -1792,7 +1788,6 @@ dependencies = [
  "twilight-embed-builder",
  "twilight-gateway",
  "twilight-http",
- "twilight-model",
  "twilight-standby",
  "twilight-util",
  "uwl",
@@ -2519,14 +2514,6 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "twilight-model",
-]
-
-[[package]]
-name = "twilight-mention"
-version = "0.5.1"
-source = "git+https://github.com/twilight-rs/twilight?branch=feature/message-components#e6717115d60682a742d31ed2bceb64b6dc7eb926"
-dependencies = [
  "twilight-model",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,8 +98,9 @@ dependencies = [
 
 [[package]]
 name = "bson"
-version = "2.0.0-beta.2"
-source = "git+https://github.com/mongodb/bson-rust#50621ff9f5150c3fd9dfd9218897c5a854d577a0"
+version = "2.0.0-beta.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ae99d761c932e2c26fa783d8672d9d4ef601b04a7ecc621509cdb27ff6ce9e4"
 dependencies = [
  "ahash",
  "base64",
@@ -808,9 +809,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
+checksum = "399c583b2979440c60be0821a6199eca73bc3c8dcd9d070d75ac726e2c6186e5"
 dependencies = [
  "bytes",
  "http",
@@ -965,9 +966,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
-version = "0.3.51"
+version = "0.3.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
+checksum = "ce791b7ca6638aae45be056e068fc756d871eb3b3b10b8efa62d1c9cec616752"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -980,9 +981,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.98"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
 
 [[package]]
 name = "libz-sys"
@@ -1115,8 +1116,8 @@ dependencies = [
 
 [[package]]
 name = "mongodb"
-version = "2.0.0-beta.2"
-source = "git+https://github.com/mongodb/mongo-rust-driver?branch=master#1fc1611b4d8d2c88490d3d4a43152d312c063d7e"
+version = "2.0.0-beta.3"
+source = "git+https://github.com/mongodb/mongo-rust-driver?branch=master#6bd7b3924665c43c7ced86375d7926cc0737a8a9"
 dependencies = [
  "async-trait",
  "base64",
@@ -1468,9 +1469,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.24.1"
+version = "2.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db50e77ae196458ccd3dc58a31ea1a90b0698ab1b7928d89f644c25d72070267"
+checksum = "020f86b07722c5c4291f7c723eac4676b3892d47d9a7708dc2779696407f039b"
 
 [[package]]
 name = "quick-error"
@@ -1571,7 +1572,7 @@ dependencies = [
 [[package]]
 name = "redis"
 version = "0.21.1-alpha.0"
-source = "git+https://github.com/mitsuhiko/redis-rs?branch=master#ab5c06795388011c609a977ac167f83f9142ed0a"
+source = "git+https://github.com/mitsuhiko/redis-rs?branch=master#beddf5aba054051b22aa96eb4b59b559fabd5b52"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1590,9 +1591,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
 ]
@@ -1898,9 +1899,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.126"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
+checksum = "f03b9878abf6d14e6779d3f24f07b2cfa90352cfec4acc5aab8f1ac7f146fae8"
 dependencies = [
  "serde_derive",
 ]
@@ -1936,9 +1937,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.126"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
+checksum = "a024926d3432516606328597e0f224a51355a493b49fdd67e9209187cbe55ecc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2052,18 +2053,18 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c719719ee05df97490f80a45acfc99e5a30ce98a1e4fb67aee422745ae14e3"
+checksum = "740223c51853f3145fe7c90360d2d4232f2b62e3449489c207eccde818979982"
 dependencies = [
  "lazy_static",
 ]
 
 [[package]]
 name = "slab"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
+checksum = "c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590"
 
 [[package]]
 name = "smallvec"
@@ -2698,9 +2699,9 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
+checksum = "b608ecc8f4198fe8680e2ed18eccab5f0cd4caaf3d83516fa5fb2e927fda2586"
 dependencies = [
  "cfg-if",
  "serde",
@@ -2710,9 +2711,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
+checksum = "580aa3a91a63d23aac5b6b267e2d13cb4f363e31dce6c352fca4752ae12e479f"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -2725,9 +2726,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.24"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fba7978c679d53ce2d0ac80c8c175840feb849a161664365d1287b41f2e67f1"
+checksum = "16646b21c3add8e13fdb8f20172f8a28c3dbf62f45406bcff0233188226cfe0c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2737,9 +2738,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
+checksum = "171ebf0ed9e1458810dfcb31f2e766ad6b3a89dbda42d8901f2b268277e5f09c"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2747,9 +2748,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
+checksum = "6c2657dd393f03aa2a659c25c6ae18a13a4048cebd220e147933ea837efc589f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2760,15 +2761,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
+checksum = "2e0c4a743a309662d45f4ede961d7afa4ba4131a59a639f29b0069c3798bbcc2"
 
 [[package]]
 name = "web-sys"
-version = "0.3.51"
+version = "0.3.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
+checksum = "01c70a82d842c9979078c772d4a1344685045f1a5628f677c2b2eab4dd7d2696"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,9 +60,9 @@ checksum = "e906254e445520903e7fc9da4f709886c84ae4bc4ddaf0e093188d66df4dc820"
 
 [[package]]
 name = "async-trait"
-version = "0.1.50"
+version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b98e84bbb4cbcdd97da190ba0c58a1bb0de2c1fdf67d159e192ed766aeca722"
+checksum = "44318e776df68115a881de9a8fd1b9e53368d7a4a5ce4cc48517da3393233a5e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -99,7 +99,7 @@ dependencies = [
 [[package]]
 name = "bson"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/mongodb/bson-rust#7ccf82b3dc66141d8292a5c1e253362abaa13d5c"
+source = "git+https://github.com/mongodb/bson-rust#50621ff9f5150c3fd9dfd9218897c5a854d577a0"
 dependencies = [
  "ahash",
  "base64",
@@ -122,9 +122,9 @@ checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
 
 [[package]]
 name = "bytemuck"
-version = "1.7.0"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9966d2ab714d0f785dbac0a0396251a35280aeb42413281617d0209ab4898435"
+checksum = "72957246c41db82b8ef88a5486143830adeb8227ef9837740bdec67724cf2c5b"
 
 [[package]]
 name = "byteorder"
@@ -595,9 +595,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7e43a803dae2fa37c1f6a8fe121e1f7bf9548b4dfc0522a42f34145dadfc27"
+checksum = "1adc00f486adfc9ce99f77d717836f0c5aa84965eb0b4f051f4e83f7cab53f8b"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -610,9 +610,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e682a68b29a882df0545c143dc3646daefe80ba479bcdede94d5a703de2871e2"
+checksum = "74ed2411805f6e4e3d9bc904c95d5d423b89b3b25dc0250aa74729de20629ff9"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -620,15 +620,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
+checksum = "af51b1b4a7fdff033703db39de8802c673eb91855f2e0d47dcf3bf2c0ef01f99"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "badaa6a909fac9e7236d0620a2f57f7664640c56575b71a7552fbd68deafab79"
+checksum = "4d0d535a57b87e1ae31437b892713aee90cd2d7b0ee48727cd11fc72ef54761c"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -637,15 +637,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1"
+checksum = "0b0e06c393068f3a6ef246c75cdca793d6a46347e75286933e5e75fd2fd11582"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c40298486cdf52cc00cd6d6987892ba502c7656a16a4192a9992b1ccedd121"
+checksum = "c54913bae956fb8df7f4dc6fc90362aa72e69148e3f39041fbe8742d21e0ac57"
 dependencies = [
  "autocfg",
  "proc-macro-hack",
@@ -656,21 +656,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a57bead0ceff0d6dde8f465ecd96c9338121bb7717d3e7b108059531870c4282"
+checksum = "c0f30aaa67363d119812743aa5f33c201a7a66329f97d1a887022971feea4b53"
 
 [[package]]
 name = "futures-task"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a16bef9fc1a4dddb5bee51c989e3fbba26569cbb0e31f5b303c184e3dd33dae"
+checksum = "bbe54a98670017f3be909561f6ad13e810d9a51f3f061b902062ca3da80799f2"
 
 [[package]]
 name = "futures-util"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb5c238d27e2bf94ffdfd27b2c29e3df4a68c4193bb6427384259e2bf191967"
+checksum = "67eb846bfd58e44a8481a00049e82c43e0ccb5d61f8dc071057cb19249dd4d78"
 dependencies = [
  "autocfg",
  "futures-channel",
@@ -831,9 +831,9 @@ checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
 name = "hyper"
-version = "0.14.10"
+version = "0.14.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7728a72c4c7d72665fde02204bcbd93b247721025b222ef78606f14513e0fd03"
+checksum = "0b61cf2d1aebcf6e6352c97b81dc2244ca29194be1b276f5d8ad5c6330fffb11"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -846,7 +846,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.0",
+ "socket2 0.4.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -1116,7 +1116,7 @@ dependencies = [
 [[package]]
 name = "mongodb"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/mongodb/mongo-rust-driver?branch=master#6826e0cae7ce87d166e1a85e8c9480e7dab2b823"
+source = "git+https://github.com/mongodb/mongo-rust-driver?branch=master#1fc1611b4d8d2c88490d3d4a43152d312c063d7e"
 dependencies = [
  "async-trait",
  "base64",
@@ -1143,7 +1143,7 @@ dependencies = [
  "serde_with",
  "sha-1",
  "sha2",
- "socket2 0.4.0",
+ "socket2 0.4.1",
  "stringprep",
  "strsim",
  "take_mut",
@@ -1332,18 +1332,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7509cc106041c40a4518d2af7a61530e1eed0e6285296a3d8c5472806ccc4a4"
+checksum = "576bc800220cc65dac09e99e97b08b358cfab6e17078de8dc5fee223bd2d0c08"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c950132583b500556b1efd71d45b319029f2b71518d979fcc208e16b42426f"
+checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1444,9 +1444,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
 dependencies = [
  "unicode-xid",
 ]
@@ -1952,9 +1952,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.64"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
 dependencies = [
  "indexmap",
  "itoa",
@@ -2089,9 +2089,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
+checksum = "765f090f0e423d2b55843402a07915add955e7d60657db13707a159727326cad"
 dependencies = [
  "libc",
  "winapi",
@@ -2127,9 +2127,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.73"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
+checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2184,9 +2184,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac2e1d4bd0f75279cfd5a076e0d578bbf02c22b7c39e766c437dd49b3ec43e0"
+checksum = "848a1e1181b9f6753b5e96a092749e29b11d19ede67dfbbd6c7dc7e0f49b5338"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2199,9 +2199,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2602b8af3767c285202012822834005f596c811042315fa7e9f5b12b2a43207"
+checksum = "4b7b349f11a7047e6d1276853e612d152f5e8a352c61917887cc2169e2366b4c"
 dependencies = [
  "autocfg",
  "bytes",

--- a/cache/Cargo.toml
+++ b/cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rowifi-cache"
-version = "3.1.0"
+version = "3.1.1"
 authors = ["Gautam.A <gautam.abhyankar@gmail.com>"]
 edition = "2018"
 

--- a/cache/Cargo.toml
+++ b/cache/Cargo.toml
@@ -10,4 +10,3 @@ edition = "2018"
 dashmap = "4"
 rowifi-models = { path = "../models" }
 tracing = "0"
-twilight-model = { branch = "feature/message-components", git = "https://github.com/twilight-rs/twilight" }

--- a/cache/src/event.rs
+++ b/cache/src/event.rs
@@ -1,9 +1,4 @@
-use std::{
-    ops::Deref,
-    sync::{atomic::Ordering, Arc},
-};
-use tracing::{debug, info};
-use twilight_model::{
+use rowifi_models::discord::{
     application::interaction::Interaction,
     channel::Channel,
     gateway::{
@@ -15,6 +10,11 @@ use twilight_model::{
         },
     },
 };
+use std::{
+    ops::Deref,
+    sync::{atomic::Ordering, Arc},
+};
+use tracing::{debug, info};
 
 use super::{Cache, CacheError, CachedMember};
 

--- a/cache/src/lib.rs
+++ b/cache/src/lib.rs
@@ -14,7 +14,15 @@ mod event;
 mod models;
 
 use dashmap::{mapref::entry::Entry, DashMap, DashSet};
-use rowifi_models::stats::BotStats;
+use rowifi_models::{
+    discord::{
+        channel::{permission_overwrite::PermissionOverwriteType, GuildChannel},
+        guild::{Guild, Member, Permissions, Role},
+        id::{ChannelId, GuildId, RoleId, UserId},
+        user::{CurrentUser, User},
+    },
+    stats::BotStats,
+};
 use std::{
     collections::{HashMap, HashSet},
     hash::Hash,
@@ -22,12 +30,6 @@ use std::{
         atomic::{AtomicI64, Ordering},
         Arc, Mutex,
     },
-};
-use twilight_model::{
-    channel::{permission_overwrite::PermissionOverwriteType, GuildChannel},
-    guild::{Guild, Member, Permissions, Role},
-    id::{ChannelId, GuildId, RoleId, UserId},
-    user::{CurrentUser, User},
 };
 
 use event::UpdateCache;

--- a/cache/src/models/guild.rs
+++ b/cache/src/models/guild.rs
@@ -1,8 +1,8 @@
-use std::sync::{atomic::AtomicI64, Arc};
-use twilight_model::{
+use rowifi_models::discord::{
     guild::Permissions,
     id::{ChannelId, GuildId, RoleId, UserId},
 };
+use std::sync::{atomic::AtomicI64, Arc};
 
 #[derive(Debug, Clone)]
 pub struct CachedGuild {

--- a/cache/src/models/member.rs
+++ b/cache/src/models/member.rs
@@ -1,9 +1,9 @@
-use std::sync::Arc;
-use twilight_model::{
+use rowifi_models::discord::{
     guild::{Member, PartialMember},
     id::RoleId,
     user::User,
 };
+use std::sync::Arc;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct CachedMember {

--- a/cache/src/models/role.rs
+++ b/cache/src/models/role.rs
@@ -1,4 +1,4 @@
-use twilight_model::{
+use rowifi_models::discord::{
     guild::Permissions,
     id::{GuildId, RoleId},
 };

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rowifi-database"
-version = "3.1.0"
+version = "3.1.1"
 authors = ["Gautam.A <gautam.abhyankar@gmail.com>"]
 edition = "2018"
 

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -284,7 +284,10 @@ impl Database {
             Some(l) => Ok(Some(l)),
             None => {
                 let result = linked_users
-                    .find_one(doc! {"GuildId": guild_id as i64, "UserId": user_id as i64}, None)
+                    .find_one(
+                        doc! {"GuildId": guild_id as i64, "UserId": user_id as i64},
+                        None,
+                    )
                     .await?;
                 let user = match result {
                     None => return Ok(None),

--- a/framework/Cargo.toml
+++ b/framework/Cargo.toml
@@ -24,7 +24,6 @@ tokio-stream = { version = "0" }
 tower = { version = "0", features = ["util"] }
 transient-dashmap = { branch = "main", git = "https://github.com/AsianIntel/transient-dashmap" }
 twilight-embed-builder = { branch = "feature/message-components", git = "https://github.com/twilight-rs/twilight" }
-twilight-model = { branch = "feature/message-components", git = "https://github.com/twilight-rs/twilight" }
 twilight-gateway = { branch = "feature/message-components", git = "https://github.com/twilight-rs/twilight", default-features = false, features= ["zlib-stock", "rustls-webpki-roots"] }
 twilight-http = { branch = "feature/message-components", git = "https://github.com/twilight-rs/twilight", default-features = false, features = ["rustls-webpki-roots", "tracing"] }
 twilight-standby = { branch = "feature/message-components", git = "https://github.com/twilight-rs/twilight" }

--- a/framework/Cargo.toml
+++ b/framework/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rowifi-framework"
-version = "3.1.0"
+version = "3.1.1"
 authors = ["AsianIntel <gautam.abhyankar@gmail.com>"]
 edition = "2018"
 

--- a/framework/framework-derive/src/lib.rs
+++ b/framework/framework-derive/src/lib.rs
@@ -213,8 +213,8 @@ pub fn from_args_derive(input: TokenStream) -> TokenStream {
                 })
             }
 
-            fn from_interaction(options: &[twilight_model::application::interaction::application_command::CommandDataOption]) -> std::result::Result<Self, ArgumentError> {
-                use twilight_model::application::interaction::application_command::CommandDataOption;
+            fn from_interaction(options: &[rowifi_models::discord::application::interaction::application_command::CommandDataOption]) -> std::result::Result<Self, ArgumentError> {
+                use rowifi_models::discord::application::interaction::application_command::CommandDataOption;
 
                 let options = options.iter().map(|c| (c.name(), c))
                     .collect::<std::collections::HashMap<&str, &CommandDataOption>>();

--- a/framework/src/arguments.rs
+++ b/framework/src/arguments.rs
@@ -1,9 +1,12 @@
-use rowifi_models::{bind::AssetType, guild::BlacklistActionType};
-use std::{num::ParseIntError, str::FromStr};
-use twilight_model::{
-    application::interaction::application_command::CommandDataOption,
-    id::{ChannelId, RoleId, UserId},
+use rowifi_models::{
+    bind::AssetType,
+    discord::{
+        application::interaction::application_command::CommandDataOption,
+        id::{ChannelId, RoleId, UserId},
+    },
+    guild::BlacklistActionType,
 };
+use std::{num::ParseIntError, str::FromStr};
 
 use crate::utils::{parse_channel, parse_role, parse_username};
 

--- a/framework/src/bucket.rs
+++ b/framework/src/bucket.rs
@@ -1,4 +1,5 @@
 use futures_util::future::{Future, FutureExt};
+use rowifi_models::discord::id::GuildId;
 use std::{
     pin::Pin,
     sync::Arc,
@@ -7,7 +8,6 @@ use std::{
 };
 use tower::{Layer, Service};
 use transient_dashmap::TransientDashMap;
-use twilight_model::id::GuildId;
 
 use crate::{
     context::CommandContext,

--- a/framework/src/command.rs
+++ b/framework/src/command.rs
@@ -1,4 +1,11 @@
 use itertools::Itertools;
+use rowifi_models::discord::{
+    application::{
+        callback::{CallbackData, InteractionResponse},
+        interaction::application_command::CommandDataOption,
+    },
+    channel::message::MessageFlags,
+};
 use std::{
     fmt::{Debug, Formatter, Result as FmtResult},
     future::Future,
@@ -7,13 +14,6 @@ use std::{
 };
 use tower::Service;
 use twilight_embed_builder::{EmbedBuilder, EmbedFieldBuilder};
-use twilight_model::{
-    application::{
-        callback::{CallbackData, InteractionResponse},
-        interaction::application_command::CommandDataOption,
-    },
-    channel::message::MessageFlags,
-};
 
 use crate::{
     arguments::{ArgumentError, FromArgs},

--- a/framework/src/context.rs
+++ b/framework/src/context.rs
@@ -206,19 +206,6 @@ impl CommandContext {
         }
     }
 
-    pub async fn update_user(
-        &self,
-        member: Arc<CachedMember>,
-        user: &RoGuildUser,
-        server: &CachedGuild,
-        guild: &RoGuild,
-        guild_roles: &HashSet<RoleId>,
-    ) -> Result<(Vec<RoleId>, Vec<RoleId>, String), RoError> {
-        self.bot
-            .update_user(member, user, server, guild, guild_roles)
-            .await
-    }
-
     pub async fn get_linked_user(
         &self,
         user_id: UserId,
@@ -253,6 +240,7 @@ impl BotContext {
         server: &CachedGuild,
         guild: &RoGuild,
         guild_roles: &HashSet<RoleId>,
+        bypass_roblox_cache: bool,
     ) -> Result<(Vec<RoleId>, Vec<RoleId>, String), RoError> {
         let mut added_roles = Vec::<RoleId>::new();
         let mut removed_roles = Vec::<RoleId>::new();
@@ -281,7 +269,7 @@ impl BotContext {
             .iter()
             .map(|r| (r.group.id.0 as i64, r.role.rank as i64))
             .collect::<HashMap<_, _>>();
-        let roblox_user = self.roblox.get_user(user_id).await?;
+        let roblox_user = self.roblox.get_user(user_id, bypass_roblox_cache).await?;
         let command_user = RoCommandUser {
             user,
             roles: &member.roles,

--- a/framework/src/context.rs
+++ b/framework/src/context.rs
@@ -7,6 +7,11 @@ use rowifi_cache::{Cache, CachedGuild, CachedMember};
 use rowifi_database::Database;
 use rowifi_models::{
     bind::Bind,
+    discord::{
+        channel::embed::Embed,
+        id::{ChannelId, GuildId, InteractionId, MessageId, RoleId, UserId, WebhookId},
+        user::User,
+    },
     guild::{BlacklistActionType, RoGuild},
     roblox::id::{AssetId as RobloxAssetId, UserId as RobloxUserId},
     rolang::RoCommandUser,
@@ -21,11 +26,6 @@ use std::{
 };
 use twilight_gateway::Cluster;
 use twilight_http::Client as Http;
-use twilight_model::{
-    channel::embed::Embed,
-    id::{ChannelId, GuildId, InteractionId, MessageId, RoleId, UserId, WebhookId},
-    user::User,
-};
 use twilight_standby::Standby;
 use twilight_util::link::webhook;
 

--- a/framework/src/context.rs
+++ b/framework/src/context.rs
@@ -57,6 +57,8 @@ pub struct BotContextRef {
     pub nickname_bypass_roles: DashMap<GuildId, Vec<RoleId>>,
     /// The map containing log channels of all servers
     pub log_channels: DashMap<GuildId, ChannelId>,
+    /// The array containing the message ids wit active components
+    pub ignore_message_components: DashSet<MessageId>,
 
     // Twilight Components
     /// The module used to make requests to discord
@@ -151,6 +153,7 @@ impl BotContext {
                 bypass_roles: DashMap::new(),
                 nickname_bypass_roles: DashMap::new(),
                 log_channels: DashMap::new(),
+                ignore_message_components: DashSet::new(),
                 http,
                 cache,
                 cluster,

--- a/framework/src/context.rs
+++ b/framework/src/context.rs
@@ -17,7 +17,7 @@ use std::{
     borrow::ToOwned,
     collections::{HashMap, HashSet},
     ops::Deref,
-    sync::Arc,
+    sync::{atomic::AtomicBool, Arc},
 };
 use twilight_gateway::Cluster;
 use twilight_http::Client as Http;
@@ -111,6 +111,8 @@ pub struct CommandContext {
     pub interaction_id: Option<InteractionId>,
     /// The token of the interaction. This is used to make followups or edit the original response
     pub interaction_token: Option<String>,
+    /// Bool whether callback has been invoked
+    pub callback_invoked: Arc<AtomicBool>,
 }
 
 impl BotContext {

--- a/framework/src/extensions/embed.rs
+++ b/framework/src/extensions/embed.rs
@@ -1,5 +1,5 @@
+use rowifi_models::discord::id::RoleId;
 use twilight_embed_builder::{EmbedBuilder, EmbedFieldBuilder, EmbedFooterBuilder};
-use twilight_model::id::RoleId;
 
 use crate::utils::Color;
 

--- a/framework/src/extensions/standby.rs
+++ b/framework/src/extensions/standby.rs
@@ -1,5 +1,5 @@
+use rowifi_models::discord::{application::interaction::Interaction, id::MessageId};
 use twilight_gateway::Event;
-use twilight_model::{application::interaction::Interaction, id::MessageId};
 use twilight_standby::{Standby, WaitForEventStream};
 
 pub trait StandbyExtensions {

--- a/framework/src/lib.rs
+++ b/framework/src/lib.rs
@@ -28,15 +28,7 @@ pub mod utils;
 use futures_util::future::{ready, Either, Ready};
 use itertools::Itertools;
 use rowifi_cache::{CachedGuild, CachedMember};
-use std::{
-    future::Future,
-    pin::Pin,
-    sync::{atomic::AtomicBool, Arc},
-    task::{Context, Poll},
-};
-use tower::Service;
-use twilight_embed_builder::{EmbedBuilder, EmbedFieldBuilder};
-use twilight_model::{
+use rowifi_models::discord::{
     application::{
         callback::{CallbackData, InteractionResponse},
         interaction::{application_command::CommandDataOption, Interaction},
@@ -46,6 +38,14 @@ use twilight_model::{
     guild::Permissions,
     id::{GuildId, UserId},
 };
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::{atomic::AtomicBool, Arc},
+    task::{Context, Poll},
+};
+use tower::Service;
+use twilight_embed_builder::{EmbedBuilder, EmbedFieldBuilder};
 use uwl::Stream;
 
 use arguments::Arguments;

--- a/framework/src/lib.rs
+++ b/framework/src/lib.rs
@@ -31,7 +31,7 @@ use rowifi_cache::{CachedGuild, CachedMember};
 use std::{
     future::Future,
     pin::Pin,
-    sync::Arc,
+    sync::{atomic::AtomicBool, Arc},
     task::{Context, Poll},
 };
 use tower::Service;
@@ -110,6 +110,7 @@ impl Framework {
                     message_id: Some(msg.id),
                     interaction_id: None,
                     interaction_token: None,
+                    callback_invoked: Arc::new(AtomicBool::new(false)),
                 };
                 let req = ServiceRequest::Help(args, embed);
                 return cmd.call((ctx, req));
@@ -251,6 +252,7 @@ impl Service<&Event> for Framework {
                     message_id: Some(msg.id),
                     interaction_id: None,
                     interaction_token: None,
+                    callback_invoked: Arc::new(AtomicBool::new(false)),
                 };
 
                 let request = ServiceRequest::Message(cmd_str);
@@ -308,6 +310,7 @@ impl Service<&Event> for Framework {
                         message_id: None,
                         interaction_id: Some(id),
                         interaction_token: Some(top_command.token.clone()),
+                        callback_invoked: Arc::new(AtomicBool::new(false)),
                     };
 
                     let request = ServiceRequest::Interaction(command_options.clone());

--- a/framework/src/parser.rs
+++ b/framework/src/parser.rs
@@ -1,4 +1,4 @@
-use twilight_model::id::GuildId;
+use rowifi_models::discord::id::GuildId;
 use uwl::Stream;
 
 use crate::context::BotContext;

--- a/framework/src/prelude.rs
+++ b/framework/src/prelude.rs
@@ -6,11 +6,7 @@ pub use crate::extensions::*;
 pub use crate::utils::*;
 
 pub use framework_derive::FromArgs;
-pub use std::time::Duration;
-pub use tokio_stream::StreamExt;
-pub use tower::{Service, ServiceExt};
-pub use twilight_embed_builder::*;
-pub use twilight_model::{
+pub use rowifi_models::discord::{
     application::{
         callback::{CallbackData, InteractionResponse},
         component::{
@@ -24,3 +20,7 @@ pub use twilight_model::{
     channel::ReactionType,
     gateway::event::Event,
 };
+pub use std::time::Duration;
+pub use tokio_stream::StreamExt;
+pub use tower::{Service, ServiceExt};
+pub use twilight_embed_builder::*;

--- a/framework/src/respond.rs
+++ b/framework/src/respond.rs
@@ -1,4 +1,7 @@
 use futures_util::future::FutureExt;
+use rowifi_models::discord::{
+    application::component::Component, channel::embed::Embed, id::MessageId,
+};
 use std::{
     future::Future,
     pin::Pin,
@@ -12,7 +15,6 @@ use twilight_http::{
     },
     Error as DiscordHttpError,
 };
-use twilight_model::{application::component::Component, channel::embed::Embed, id::MessageId};
 
 use crate::context::CommandContext;
 

--- a/framework/src/utils.rs
+++ b/framework/src/utils.rs
@@ -4,7 +4,22 @@ use crate::{
     extensions::StandbyExtensions,
 };
 
-use rowifi_models::bind::Template;
+use rowifi_models::{
+    bind::Template,
+    discord::{
+        application::{
+            callback::{CallbackData, InteractionResponse},
+            component::{
+                action_row::ActionRow,
+                button::{Button, ButtonStyle},
+                Component, SelectMenu,
+            },
+            interaction::Interaction,
+        },
+        channel::{embed::Embed, ReactionType},
+        gateway::event::Event,
+    },
+};
 use std::{
     cmp::{max, min},
     num::ParseIntError,
@@ -12,19 +27,6 @@ use std::{
     time::Duration,
 };
 use tokio_stream::StreamExt;
-use twilight_model::{
-    application::{
-        callback::{CallbackData, InteractionResponse},
-        component::{
-            action_row::ActionRow,
-            button::{Button, ButtonStyle},
-            Component, SelectMenu,
-        },
-        interaction::Interaction,
-    },
-    channel::{embed::Embed, ReactionType},
-    gateway::event::Event,
-};
 
 pub enum Color {
     Red = 0x00E7_4C3C,

--- a/framework/src/utils.rs
+++ b/framework/src/utils.rs
@@ -53,12 +53,9 @@ pub async fn await_template_reply(
     mut select_menu: SelectMenu,
 ) -> Result<Template, RoError> {
     let select_custom_id = select_menu.custom_id.clone();
-    let message = ctx
-        .bot
-        .http
-        .create_message(ctx.channel_id)
+    let message_id = ctx
+        .respond()
         .content(question)
-        .unwrap()
         .components(vec![
             Component::ActionRow(ActionRow {
                 components: vec![Component::SelectMenu(select_menu.clone())],
@@ -74,10 +71,9 @@ pub async fn await_template_reply(
                 })],
             }),
         ])
-        .unwrap()
         .await?;
 
-    let message_id = message.id;
+    let message_id = message_id.unwrap();
     let author_id = ctx.author.id;
 
     select_menu.disabled = true;
@@ -158,14 +154,6 @@ pub async fn await_template_reply(
                     .await;
             }
         } else if let Event::MessageCreate(msg) = &event {
-            ctx.bot
-                .http
-                .update_message(message.channel_id, message_id)
-                .components(Some(vec![Component::ActionRow(ActionRow {
-                    components: vec![Component::SelectMenu(select_menu.clone())],
-                })]))
-                .unwrap()
-                .await?;
             ctx.bot.ignore_message_components.remove(&message_id);
             return Ok(Template(msg.content.clone()));
         }
@@ -176,12 +164,9 @@ pub async fn await_template_reply(
 }
 
 pub async fn await_reply(question: &str, ctx: &CommandContext) -> Result<String, RoError> {
-    let message = ctx
-        .bot
-        .http
-        .create_message(ctx.channel_id)
+    let message_id = ctx
+        .respond()
         .content(question)
-        .unwrap()
         .components(vec![Component::ActionRow(ActionRow {
             components: vec![Component::Button(Button {
                 custom_id: Some("reply-cancel".into()),
@@ -192,9 +177,8 @@ pub async fn await_reply(question: &str, ctx: &CommandContext) -> Result<String,
                 url: None,
             })],
         })])
-        .unwrap()
         .await?;
-    let message_id = message.id;
+    let message_id = message_id.unwrap();
     let author_id = ctx.author.id;
 
     let stream = ctx
@@ -268,12 +252,6 @@ pub async fn await_reply(question: &str, ctx: &CommandContext) -> Result<String,
                     .await;
             }
         } else if let Event::MessageCreate(msg) = &event {
-            ctx.bot
-                .http
-                .update_message(message.channel_id, message_id)
-                .components(None)
-                .unwrap()
-                .await?;
             ctx.bot.ignore_message_components.remove(&message_id);
             return Ok(msg.content.clone());
         }
@@ -290,20 +268,11 @@ pub async fn paginate_embed(
 ) -> Result<(), RoError> {
     let page_count = page_count;
     if page_count <= 1 {
-        let _ = ctx
-            .bot
-            .http
-            .create_message(ctx.channel_id)
-            .embeds(vec![pages[0].clone()])
-            .unwrap()
-            .await?;
+        ctx.respond().embeds(vec![pages[0].clone()]).await?;
     } else {
-        let m = ctx
-            .bot
-            .http
-            .create_message(ctx.channel_id)
+        let message_id = ctx
+            .respond()
             .embeds(vec![pages[0].clone()])
-            .unwrap()
             .components(vec![Component::ActionRow(ActionRow {
                 components: vec![
                     Component::Button(Button {
@@ -348,11 +317,10 @@ pub async fn paginate_embed(
                     }),
                 ],
             })])
-            .unwrap()
             .await?;
 
         //Get some easy named vars
-        let message_id = m.id;
+        let message_id = message_id.unwrap();
         let author_id = ctx.author.id;
         let http = ctx.bot.http.clone();
 

--- a/models/Cargo.toml
+++ b/models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rowifi-models"
-version = "3.1.0"
+version = "3.1.1"
 authors = ["Gautam.A <gautam.abhyankar@gmail.com>"]
 edition = "2018"
 

--- a/models/src/events.rs
+++ b/models/src/events.rs
@@ -39,4 +39,7 @@ pub struct EventType {
 
     #[serde(rename = "XP")]
     pub xp: i64,
+
+    #[serde(rename = "Disabled", default)]
+    pub disabled: bool,
 }

--- a/models/src/lib.rs
+++ b/models/src/lib.rs
@@ -58,3 +58,5 @@ pub mod roblox;
 pub mod rolang;
 pub mod stats;
 pub mod user;
+
+pub use twilight_model as discord;

--- a/roblox/Cargo.toml
+++ b/roblox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roblox"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["AsianIntel <gautam.abhyankar@gmail.com>"]
 edition = "2018"
 

--- a/rowifi/Cargo.toml
+++ b/rowifi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rowifi"
-version = "3.1.0"
+version = "3.1.1"
 authors = ["Gautam.A <gautam.abhyankar@gmail.com>"]
 edition = "2018"
 

--- a/rowifi/Cargo.toml
+++ b/rowifi/Cargo.toml
@@ -35,11 +35,8 @@ regex = "1"
 sha2 = "0"
 
 # Twilight Modules
-twilight-embed-builder = { branch = "feature/message-components", git = "https://github.com/twilight-rs/twilight" }
 twilight-gateway = { branch = "feature/message-components", git = "https://github.com/twilight-rs/twilight", default-features = false, features= ["zlib-stock", "rustls-webpki-roots"] }
 twilight-http = { branch = "feature/message-components", git = "https://github.com/twilight-rs/twilight", default-features = false, features = ["rustls-webpki-roots", "tracing"] }
-twilight-mention = { branch = "feature/message-components", git = "https://github.com/twilight-rs/twilight" } # TODO: Remove this
-twilight-model = { branch = "feature/message-components", git = "https://github.com/twilight-rs/twilight" }
 twilight-standby = { branch = "feature/message-components", git = "https://github.com/twilight-rs/twilight" }
 
 # Utilities Crates

--- a/rowifi/src/commands/analytics/mod.rs
+++ b/rowifi/src/commands/analytics/mod.rs
@@ -28,6 +28,12 @@ pub fn analytics_config(cmds: &mut Vec<Command>) {
         .description("Command to view the membercount analytics of a group")
         .handler(analytics_view);
 
+    let analytics_list_cmd = Command::builder()
+        .level(RoLevel::Admin)
+        .names(&["list"])
+        .description("Command to view all registered groups")
+        .handler(analytics_config_view);
+
     let analytics = Command::builder()
         .level(RoLevel::Admin)
         .names(&["analytics"])
@@ -36,6 +42,7 @@ pub fn analytics_config(cmds: &mut Vec<Command>) {
         .sub_command(analytics_register_cmd)
         .sub_command(analytics_unregister_cmd)
         .sub_command(analytics_view_cmd)
+        .sub_command(analytics_list_cmd)
         .handler(analytics_config_view);
     cmds.push(analytics);
 }

--- a/rowifi/src/commands/api/mod.rs
+++ b/rowifi/src/commands/api/mod.rs
@@ -72,7 +72,7 @@ pub async fn api_generate(ctx: CommandContext) -> CommandResult {
         return Ok(());
     }
 
-    let filter = doc! {"_id": guild_id.0};
+    let filter = doc! {"_id": guild_id.0 as i64};
     let update = doc! {"$set": {"APIKey": hash}};
     ctx.bot.database.modify_guild(filter, update).await?;
     Ok(())

--- a/rowifi/src/commands/assetbinds/delete.rs
+++ b/rowifi/src/commands/assetbinds/delete.rs
@@ -92,6 +92,7 @@ pub async fn assetbinds_delete(ctx: CommandContext, args: DeleteArguments) -> Co
         .timeout(Duration::from_secs(60));
     tokio::pin!(stream);
 
+    ctx.bot.ignore_message_components.insert(message_id);
     while let Some(Ok(event)) = stream.next().await {
         if let Event::InteractionCreate(interaction) = &event {
             if let Interaction::MessageComponent(message_component) = &interaction.0 {
@@ -131,7 +132,7 @@ pub async fn assetbinds_delete(ctx: CommandContext, args: DeleteArguments) -> Co
                         .embeds(vec![embed])
                         .await?;
 
-                    return Ok(());
+                    break;
                 }
                 let _ = ctx
                     .bot
@@ -153,23 +154,7 @@ pub async fn assetbinds_delete(ctx: CommandContext, args: DeleteArguments) -> Co
             }
         }
     }
-
-    if let Some(interaction_token) = &ctx.interaction_token {
-        ctx.bot
-            .http
-            .update_interaction_original(interaction_token)
-            .unwrap()
-            .components(None)
-            .unwrap()
-            .await?;
-    } else {
-        ctx.bot
-            .http
-            .update_message(ctx.channel_id, message_id)
-            .components(None)
-            .unwrap()
-            .await?;
-    }
+    ctx.bot.ignore_message_components.remove(&message_id);
 
     Ok(())
 }

--- a/rowifi/src/commands/assetbinds/delete.rs
+++ b/rowifi/src/commands/assetbinds/delete.rs
@@ -1,8 +1,8 @@
 use mongodb::bson::{self, doc};
 use rowifi_framework::prelude::*;
+use rowifi_models::discord::{application::interaction::Interaction, gateway::event::Event};
 use std::time::Duration;
 use tokio_stream::StreamExt;
-use twilight_model::{application::interaction::Interaction, gateway::event::Event};
 
 #[derive(FromArgs)]
 pub struct DeleteArguments {

--- a/rowifi/src/commands/assetbinds/mod.rs
+++ b/rowifi/src/commands/assetbinds/mod.rs
@@ -4,8 +4,6 @@ mod new;
 
 use itertools::Itertools;
 use rowifi_framework::prelude::*;
-use twilight_mention::Mention;
-use twilight_model::id::RoleId;
 
 pub use delete::assetbinds_delete;
 pub use modify::assetbinds_modify;
@@ -80,7 +78,7 @@ pub async fn assetbind(ctx: CommandContext) -> CommandResult {
             let roles_str = ab
                 .discord_roles
                 .iter()
-                .map(|r| RoleId(*r as u64).mention().to_string())
+                .map(|r| format!("<@&{}>", r))
                 .collect::<String>();
             let nick = match &ab.template {
                 Some(template) => format!("Template: {}\n", template),

--- a/rowifi/src/commands/assetbinds/modify.rs
+++ b/rowifi/src/commands/assetbinds/modify.rs
@@ -113,11 +113,11 @@ async fn add_roles(
     guild: &RoGuild,
     asset_id: i64,
     roles: &str,
-) -> Result<Vec<u64>, RoError> {
+) -> Result<Vec<i64>, RoError> {
     let mut role_ids = Vec::new();
     for r in roles.split_ascii_whitespace() {
         if let Some(r) = parse_role(r) {
-            role_ids.push(r);
+            role_ids.push(r as i64);
         }
     }
     let filter = doc! {"_id": guild.id, "AssetBinds._id": asset_id};
@@ -131,11 +131,11 @@ async fn remove_roles(
     guild: &RoGuild,
     asset_id: i64,
     roles: &str,
-) -> Result<Vec<u64>, RoError> {
+) -> Result<Vec<i64>, RoError> {
     let mut role_ids = Vec::new();
     for r in roles.split_ascii_whitespace() {
         if let Some(r) = parse_role(r) {
-            role_ids.push(r);
+            role_ids.push(r as i64);
         }
     }
     let filter = doc! {"_id": guild.id, "AssetBinds._id": asset_id};

--- a/rowifi/src/commands/assetbinds/new.rs
+++ b/rowifi/src/commands/assetbinds/new.rs
@@ -1,8 +1,9 @@
 use mongodb::bson::{doc, to_bson};
 use rowifi_framework::prelude::*;
-use rowifi_models::bind::{AssetBind, AssetType, Template};
-use twilight_mention::Mention;
-use twilight_model::id::RoleId;
+use rowifi_models::{
+    bind::{AssetBind, AssetType, Template},
+    discord::id::RoleId,
+};
 
 #[derive(FromArgs)]
 pub struct NewArguments {
@@ -91,7 +92,7 @@ pub async fn assetbinds_new(ctx: CommandContext, args: NewArguments) -> CommandR
         priority,
         bind.discord_roles
             .iter()
-            .map(|r| RoleId(*r as u64).mention().to_string())
+            .map(|r| format!("<@&{}> ", r))
             .collect::<String>()
     );
     let embed = EmbedBuilder::new()

--- a/rowifi/src/commands/assetbinds/new.rs
+++ b/rowifi/src/commands/assetbinds/new.rs
@@ -137,6 +137,7 @@ pub async fn assetbinds_new(ctx: CommandContext, args: NewArguments) -> CommandR
         .timeout(Duration::from_secs(60));
     tokio::pin!(stream);
 
+    ctx.bot.ignore_message_components.insert(message_id);
     while let Some(Ok(event)) = stream.next().await {
         if let Event::InteractionCreate(interaction) = &event {
             if let Interaction::MessageComponent(message_component) = &interaction.0 {
@@ -175,7 +176,7 @@ pub async fn assetbinds_new(ctx: CommandContext, args: NewArguments) -> CommandR
                         .embeds(vec![embed])
                         .await?;
 
-                    return Ok(());
+                    break;
                 }
                 let _ = ctx
                     .bot
@@ -197,23 +198,7 @@ pub async fn assetbinds_new(ctx: CommandContext, args: NewArguments) -> CommandR
             }
         }
     }
-
-    if let Some(interaction_token) = &ctx.interaction_token {
-        ctx.bot
-            .http
-            .update_interaction_original(interaction_token)
-            .unwrap()
-            .components(None)
-            .unwrap()
-            .await?;
-    } else {
-        ctx.bot
-            .http
-            .update_message(ctx.channel_id, message_id)
-            .components(None)
-            .unwrap()
-            .await?;
-    }
+    ctx.bot.ignore_message_components.remove(&message_id);
 
     Ok(())
 }

--- a/rowifi/src/commands/backup/restore.rs
+++ b/rowifi/src/commands/backup/restore.rs
@@ -1,7 +1,9 @@
 use rowifi_framework::prelude::*;
-use rowifi_models::guild::{GuildType, RoGuild};
+use rowifi_models::{
+    discord::id::{ChannelId, RoleId},
+    guild::{GuildType, RoGuild},
+};
 use std::collections::HashMap;
-use twilight_model::id::{ChannelId, RoleId};
 
 use super::BackupArguments;
 

--- a/rowifi/src/commands/blacklists/custom.rs
+++ b/rowifi/src/commands/blacklists/custom.rs
@@ -133,6 +133,7 @@ pub async fn blacklist_custom(
         .timeout(Duration::from_secs(60));
     tokio::pin!(stream);
 
+    ctx.bot.ignore_message_components.insert(message_id);
     while let Some(Ok(event)) = stream.next().await {
         if let Event::InteractionCreate(interaction) = &event {
             if let Interaction::MessageComponent(message_component) = &interaction.0 {
@@ -171,7 +172,7 @@ pub async fn blacklist_custom(
                         .embeds(vec![embed])
                         .await?;
 
-                    return Ok(());
+                    break;
                 }
                 let _ = ctx
                     .bot
@@ -193,22 +194,7 @@ pub async fn blacklist_custom(
             }
         }
     }
+    ctx.bot.ignore_message_components.remove(&message_id);
 
-    if let Some(interaction_token) = &ctx.interaction_token {
-        ctx.bot
-            .http
-            .update_interaction_original(interaction_token)
-            .unwrap()
-            .components(None)
-            .unwrap()
-            .await?;
-    } else {
-        ctx.bot
-            .http
-            .update_message(ctx.channel_id, message_id)
-            .components(None)
-            .unwrap()
-            .await?;
-    }
     Ok(())
 }

--- a/rowifi/src/commands/blacklists/custom.rs
+++ b/rowifi/src/commands/blacklists/custom.rs
@@ -56,7 +56,7 @@ pub async fn blacklist_custom(
         .iter()
         .map(|r| (r.group.id.0 as i64, i64::from(r.role.rank)))
         .collect::<HashMap<_, _>>();
-    let roblox_user = ctx.bot.roblox.get_user(user_id).await?;
+    let roblox_user = ctx.bot.roblox.get_user(user_id, false).await?;
 
     let command_user = RoCommandUser {
         user: &user,

--- a/rowifi/src/commands/blacklists/group.rs
+++ b/rowifi/src/commands/blacklists/group.rs
@@ -75,6 +75,7 @@ pub async fn blacklist_group(ctx: CommandContext, args: BlacklistGroupArguments)
         .timeout(Duration::from_secs(300));
     tokio::pin!(stream);
 
+    ctx.bot.ignore_message_components.insert(message_id);
     while let Some(Ok(event)) = stream.next().await {
         if let Event::InteractionCreate(interaction) = &event {
             if let Interaction::MessageComponent(message_component) = &interaction.0 {
@@ -113,7 +114,7 @@ pub async fn blacklist_group(ctx: CommandContext, args: BlacklistGroupArguments)
                         .embeds(vec![embed])
                         .await?;
 
-                    return Ok(());
+                    break;
                 }
                 let _ = ctx
                     .bot
@@ -135,23 +136,7 @@ pub async fn blacklist_group(ctx: CommandContext, args: BlacklistGroupArguments)
             }
         }
     }
-
-    if let Some(interaction_token) = &ctx.interaction_token {
-        ctx.bot
-            .http
-            .update_interaction_original(interaction_token)
-            .unwrap()
-            .components(None)
-            .unwrap()
-            .await?;
-    } else {
-        ctx.bot
-            .http
-            .update_message(ctx.channel_id, message_id)
-            .components(None)
-            .unwrap()
-            .await?;
-    }
+    ctx.bot.ignore_message_components.remove(&message_id);
 
     Ok(())
 }

--- a/rowifi/src/commands/blacklists/mod.rs
+++ b/rowifi/src/commands/blacklists/mod.rs
@@ -68,12 +68,7 @@ pub async fn blacklist(ctx: CommandContext) -> CommandResult {
             .description("No blacklists were found associated with this server")
             .build()
             .unwrap();
-        ctx.bot
-            .http
-            .create_message(ctx.channel_id)
-            .embeds(vec![e])
-            .unwrap()
-            .await?;
+        ctx.respond().embeds(vec![e]).await?;
         return Ok(());
     }
 

--- a/rowifi/src/commands/blacklists/name.rs
+++ b/rowifi/src/commands/blacklists/name.rs
@@ -94,6 +94,7 @@ pub async fn blacklist_name(ctx: CommandContext, args: BlacklistNameArguments) -
         .timeout(Duration::from_secs(60));
     tokio::pin!(stream);
 
+    ctx.bot.ignore_message_components.insert(message_id);
     while let Some(Ok(event)) = stream.next().await {
         if let Event::InteractionCreate(interaction) = &event {
             if let Interaction::MessageComponent(message_component) = &interaction.0 {
@@ -132,7 +133,7 @@ pub async fn blacklist_name(ctx: CommandContext, args: BlacklistNameArguments) -
                         .embeds(vec![embed])
                         .await?;
 
-                    return Ok(());
+                    break;
                 }
                 let _ = ctx
                     .bot
@@ -154,23 +155,7 @@ pub async fn blacklist_name(ctx: CommandContext, args: BlacklistNameArguments) -
             }
         }
     }
-
-    if let Some(interaction_token) = &ctx.interaction_token {
-        ctx.bot
-            .http
-            .update_interaction_original(interaction_token)
-            .unwrap()
-            .components(None)
-            .unwrap()
-            .await?;
-    } else {
-        ctx.bot
-            .http
-            .update_message(ctx.channel_id, message_id)
-            .components(None)
-            .unwrap()
-            .await?;
-    }
+    ctx.bot.ignore_message_components.remove(&message_id);
 
     Ok(())
 }

--- a/rowifi/src/commands/custombinds/delete.rs
+++ b/rowifi/src/commands/custombinds/delete.rs
@@ -92,6 +92,7 @@ pub async fn custombinds_delete(
         .timeout(Duration::from_secs(60));
     tokio::pin!(stream);
 
+    ctx.bot.ignore_message_components.insert(message_id);
     while let Some(Ok(event)) = stream.next().await {
         if let Event::InteractionCreate(interaction) = &event {
             if let Interaction::MessageComponent(message_component) = &interaction.0 {
@@ -130,7 +131,7 @@ pub async fn custombinds_delete(
                         .embeds(vec![embed])
                         .await?;
 
-                    return Ok(());
+                    break;
                 }
                 let _ = ctx
                     .bot
@@ -152,22 +153,7 @@ pub async fn custombinds_delete(
             }
         }
     }
+    ctx.bot.ignore_message_components.remove(&message_id);
 
-    if let Some(interaction_token) = &ctx.interaction_token {
-        ctx.bot
-            .http
-            .update_interaction_original(interaction_token)
-            .unwrap()
-            .components(None)
-            .unwrap()
-            .await?;
-    } else {
-        ctx.bot
-            .http
-            .update_message(ctx.channel_id, message_id)
-            .components(None)
-            .unwrap()
-            .await?;
-    }
     Ok(())
 }

--- a/rowifi/src/commands/custombinds/mod.rs
+++ b/rowifi/src/commands/custombinds/mod.rs
@@ -62,12 +62,7 @@ pub async fn custombinds_view(ctx: CommandContext) -> CommandResult {
             .description("No custombinds were found associated with this server")
             .build()
             .unwrap();
-        ctx.bot
-            .http
-            .create_message(ctx.channel_id)
-            .embeds(vec![e])
-            .unwrap()
-            .await?;
+        ctx.respond().embeds(vec![e]).await?;
         return Ok(());
     }
 

--- a/rowifi/src/commands/custombinds/mod.rs
+++ b/rowifi/src/commands/custombinds/mod.rs
@@ -5,8 +5,6 @@ pub mod new;
 
 use itertools::Itertools;
 use rowifi_framework::prelude::*;
-use twilight_mention::Mention;
-use twilight_model::id::RoleId;
 
 use delete::custombinds_delete;
 use modify::custombinds_modify;
@@ -79,7 +77,7 @@ pub async fn custombinds_view(ctx: CommandContext) -> CommandResult {
             let roles_str = cb
                 .discord_roles
                 .iter()
-                .map(|r| RoleId(*r as u64).mention().to_string())
+                .map(|r| format!("<@&{}> ", r))
                 .collect::<String>();
             let nick = if let Some(template) = &cb.template {
                 format!("Template: `{}`\n", template)

--- a/rowifi/src/commands/custombinds/modify.rs
+++ b/rowifi/src/commands/custombinds/modify.rs
@@ -225,11 +225,11 @@ async fn add_roles(
     guild: &RoGuild,
     bind_id: i64,
     roles: &str,
-) -> Result<Vec<u64>, RoError> {
+) -> Result<Vec<i64>, RoError> {
     let mut role_ids = Vec::new();
     for r in roles.split_ascii_whitespace() {
         if let Some(r) = parse_role(r) {
-            role_ids.push(r);
+            role_ids.push(r as i64);
         }
     }
     let filter = doc! {"_id": guild.id, "CustomBinds._id": bind_id};
@@ -243,11 +243,11 @@ async fn remove_roles(
     guild: &RoGuild,
     bind_id: i64,
     roles: &str,
-) -> Result<Vec<u64>, RoError> {
+) -> Result<Vec<i64>, RoError> {
     let mut role_ids = Vec::new();
     for r in roles.split_ascii_whitespace() {
         if let Some(r) = parse_role(r) {
-            role_ids.push(r);
+            role_ids.push(r as i64);
         }
     }
     let filter = doc! {"_id": guild.id, "CustomBinds._id": bind_id};

--- a/rowifi/src/commands/custombinds/modify.rs
+++ b/rowifi/src/commands/custombinds/modify.rs
@@ -156,7 +156,7 @@ async fn modify_code<'a>(
         .iter()
         .map(|r| (r.group.id.0 as i64, i64::from(r.role.rank)))
         .collect::<HashMap<_, _>>();
-    let roblox_user = ctx.bot.roblox.get_user(user_id).await?;
+    let roblox_user = ctx.bot.roblox.get_user(user_id, false).await?;
 
     let command_user = RoCommandUser {
         user: &user,

--- a/rowifi/src/commands/custombinds/modify.rs
+++ b/rowifi/src/commands/custombinds/modify.rs
@@ -1,12 +1,12 @@
 use mongodb::bson::doc;
 use rowifi_framework::prelude::*;
 use rowifi_models::{
+    discord::id::GuildId,
     guild::RoGuild,
     roblox::id::UserId as RobloxUserId,
     rolang::{RoCommand, RoCommandUser},
 };
 use std::collections::HashMap;
-use twilight_model::id::GuildId;
 
 #[derive(FromArgs)]
 pub struct CustombindsModifyArguments {

--- a/rowifi/src/commands/custombinds/new.rs
+++ b/rowifi/src/commands/custombinds/new.rs
@@ -250,6 +250,7 @@ pub async fn custombinds_new_common(
         .timeout(Duration::from_secs(60));
     tokio::pin!(stream);
 
+    ctx.bot.ignore_message_components.insert(message_id);
     while let Some(Ok(event)) = stream.next().await {
         if let Event::InteractionCreate(interaction) = &event {
             if let Interaction::MessageComponent(message_component) = &interaction.0 {
@@ -288,7 +289,7 @@ pub async fn custombinds_new_common(
                         .embeds(vec![embed])
                         .await?;
 
-                    return Ok(());
+                    break;
                 }
                 let _ = ctx
                     .bot
@@ -310,12 +311,7 @@ pub async fn custombinds_new_common(
             }
         }
     }
+    ctx.bot.ignore_message_components.remove(&message_id);
 
-    ctx.bot
-        .http
-        .update_message(ctx.channel_id, message_id)
-        .components(None)
-        .unwrap()
-        .await?;
     Ok(())
 }

--- a/rowifi/src/commands/custombinds/new.rs
+++ b/rowifi/src/commands/custombinds/new.rs
@@ -3,12 +3,12 @@ use mongodb::bson::{doc, to_bson};
 use rowifi_framework::prelude::*;
 use rowifi_models::{
     bind::CustomBind,
+    discord::id::{GuildId, RoleId},
     guild::RoGuild,
     roblox::id::UserId as RobloxUserId,
     rolang::{RoCommand, RoCommandUser},
 };
 use std::collections::HashMap;
-use twilight_model::id::{GuildId, RoleId};
 
 #[derive(FromArgs)]
 pub struct CustombindsNewArguments {

--- a/rowifi/src/commands/custombinds/new.rs
+++ b/rowifi/src/commands/custombinds/new.rs
@@ -58,7 +58,7 @@ pub async fn custombinds_new_common(
         .iter()
         .map(|r| (r.group.id.0 as i64, i64::from(r.role.rank)))
         .collect::<HashMap<_, _>>();
-    let roblox_user = ctx.bot.roblox.get_user(user_id).await?;
+    let roblox_user = ctx.bot.roblox.get_user(user_id, false).await?;
 
     let command_user = RoCommandUser {
         user: &user,

--- a/rowifi/src/commands/custombinds/new.rs
+++ b/rowifi/src/commands/custombinds/new.rs
@@ -69,22 +69,12 @@ pub async fn custombinds_new_common(
     let command = match RoCommand::new(&code) {
         Ok(c) => c,
         Err(s) => {
-            ctx.bot
-                .http
-                .create_message(ctx.channel_id)
-                .content(s)
-                .unwrap()
-                .await?;
+            ctx.respond().content(s).await?;
             return Ok(());
         }
     };
     if let Err(res) = command.evaluate(&command_user) {
-        ctx.bot
-            .http
-            .create_message(ctx.channel_id)
-            .content(res)
-            .unwrap()
-            .await?;
+        ctx.respond().content(res).await?;
         return Ok(());
     }
 
@@ -95,7 +85,7 @@ pub async fn custombinds_new_common(
         min_values: Some(1),
         options: vec![
             SelectMenuOption {
-                default: true,
+                default: false,
                 description: Some("Sets the nickname as just the roblox username".into()),
                 emoji: None,
                 label: "{roblox-username}".into(),
@@ -152,12 +142,7 @@ pub async fn custombinds_new_common(
                 .description("Expected priority to be a number")
                 .build()
                 .unwrap();
-            ctx.bot
-                .http
-                .create_message(ctx.channel_id)
-                .embeds(vec![embed])
-                .unwrap()
-                .await?;
+            ctx.respond().embeds(vec![embed]).await?;
             return Ok(());
         }
     };
@@ -210,12 +195,9 @@ pub async fn custombinds_new_common(
         .field(EmbedFieldBuilder::new(name.clone(), desc.clone()))
         .build()
         .unwrap();
-    let message = ctx
-        .bot
-        .http
-        .create_message(ctx.channel_id)
+    let message_id = ctx
+        .respond()
         .embeds(vec![embed])
-        .unwrap()
         .components(vec![Component::ActionRow(ActionRow {
             components: vec![Component::Button(Button {
                 style: ButtonStyle::Danger,
@@ -228,7 +210,6 @@ pub async fn custombinds_new_common(
                 disabled: false,
             })],
         })])
-        .unwrap()
         .await?;
 
     let log_embed = EmbedBuilder::new()
@@ -241,7 +222,7 @@ pub async fn custombinds_new_common(
     ctx.log_guild(guild_id, log_embed).await;
 
     let author_id = ctx.author.id;
-    let message_id = message.id;
+    let message_id = message_id.unwrap();
 
     let stream = ctx
         .bot

--- a/rowifi/src/commands/custombinds/new.rs
+++ b/rowifi/src/commands/custombinds/new.rs
@@ -1,35 +1,114 @@
 use itertools::Itertools;
 use mongodb::bson::{doc, to_bson};
 use rowifi_framework::prelude::*;
-use rowifi_models::{
-    bind::CustomBind,
-    discord::id::{GuildId, RoleId},
-    guild::RoGuild,
-    roblox::id::UserId as RobloxUserId,
-    rolang::{RoCommand, RoCommandUser},
-};
+use rowifi_models::{bind::{CustomBind, Template}, discord::id::{GuildId, RoleId}, guild::RoGuild, roblox::id::UserId as RobloxUserId, rolang::{RoCommand, RoCommandUser}};
 use std::collections::HashMap;
 
-#[derive(FromArgs)]
 pub struct CustombindsNewArguments {
-    #[arg(help = "The code that makes up the bind", rest)]
     pub code: String,
+    pub template: Option<String>,
+    pub priority: Option<Option<i64>>,
+    pub discord_roles: Option<Option<String>>
+}
+
+impl FromArgs for CustombindsNewArguments {
+    fn from_args(args: &mut Arguments) -> Result<Self, ArgumentError> {
+        let code = match args.rest().map(|s| String::from_arg(s.as_str())) {
+            Some(Ok(s)) => s,
+            Some(Err(err)) => return Err(ArgumentError::ParseError{
+                expected: err.0,
+                usage: Self::generate_help(),
+                name: "code"
+            }),
+            None => return Err(ArgumentError::MissingArgument {
+                usage: Self::generate_help(),
+                name: "code"
+            })
+        };
+
+        Ok(Self {
+            code,
+            template: None,
+            priority: None,
+            discord_roles: None
+        })
+    }
+
+    fn from_interaction(options: &[CommandDataOption]) -> Result<Self, ArgumentError> {
+        let options = options.iter().map(|c| (c.name(), c))
+                    .collect::<std::collections::HashMap<&str, &CommandDataOption>>();
+
+        let code = match options.get(&"code").map(|s| String::from_interaction(*s)) {
+            Some(Ok(s)) => s,
+            Some(Err(err)) => return Err(ArgumentError::ParseError{
+                expected: err.0,
+                usage: Self::generate_help(),
+                name: "code"
+            }),
+            None => return Err(ArgumentError::MissingArgument {
+                usage: Self::generate_help(),
+                name: "code"
+            })
+        };
+
+        let template = match options.get(&"template").map(|s| String::from_interaction(*s)) {
+            Some(Ok(s)) => s,
+            Some(Err(err)) => return Err(ArgumentError::ParseError{
+                expected: err.0,
+                usage: Self::generate_help(),
+                name: "template"
+            }),
+            None => return Err(ArgumentError::MissingArgument {
+                usage: Self::generate_help(),
+                name: "template"
+            })
+        };
+
+        let priority = match options.get(&"priority").map(|s| i64::from_interaction(*s)) {
+            Some(Ok(s)) => Some(Some(s)),
+            Some(Err(err)) => return Err(ArgumentError::ParseError{
+                expected: err.0,
+                usage: Self::generate_help(),
+                name: "priority"
+            }),
+            None => Some(None)
+        };
+
+        let discord_roles = match options.get(&"discord_roles").map(|s| String::from_interaction(*s)) {
+            Some(Ok(s)) => Some(Some(s)),
+            Some(Err(err)) => return Err(ArgumentError::ParseError{
+                expected: err.0,
+                usage: Self::generate_help(),
+                name: "discord_roles"
+            }),
+            None => Some(None)
+        };
+
+        Ok(Self {
+            code,
+            template: Some(template),
+            priority,
+            discord_roles
+        })
+    }
+
+    fn generate_help() -> (&'static str, &'static str) {
+        ("code", "Code that makes up the bind")
+    }
 }
 
 pub async fn custombinds_new(ctx: CommandContext, args: CustombindsNewArguments) -> CommandResult {
     let guild_id = ctx.guild_id.unwrap();
     let guild = ctx.bot.database.get_guild(guild_id.0).await?;
 
-    let code = args.code;
-
-    custombinds_new_common(ctx, guild_id, guild, code).await
+    custombinds_new_common(ctx, guild_id, guild, args).await
 }
 
 pub async fn custombinds_new_common(
     ctx: CommandContext,
     guild_id: GuildId,
     guild: RoGuild,
-    code: String,
+    args: CustombindsNewArguments,
 ) -> CommandResult {
     let user = match ctx.get_linked_user(ctx.author.id, guild_id).await? {
         Some(u) => u,
@@ -66,7 +145,7 @@ pub async fn custombinds_new_common(
         ranks: &ranks,
         username: &roblox_user.name,
     };
-    let command = match RoCommand::new(&code) {
+    let command = match RoCommand::new(&args.code) {
         Ok(c) => c,
         Err(s) => {
             ctx.respond().content(s).await?;
@@ -78,77 +157,90 @@ pub async fn custombinds_new_common(
         return Ok(());
     }
 
-    let select_menu = SelectMenu {
-        custom_id: "template-reply".into(),
-        disabled: false,
-        max_values: Some(1),
-        min_values: Some(1),
-        options: vec![
-            SelectMenuOption {
-                default: false,
-                description: Some("Sets the nickname as just the roblox username".into()),
-                emoji: None,
-                label: "{roblox-username}".into(),
-                value: "{roblox-username}".into(),
-            },
-            SelectMenuOption {
-                default: false,
-                description: Some("Sets the nickname as the roblox id of the user".into()),
-                emoji: None,
-                label: "{roblox-id}".into(),
-                value: "{roblox-id}".into(),
-            },
-            SelectMenuOption {
-                default: false,
-                description: Some("Sets the nickname as the discord id of the user".into()),
-                emoji: None,
-                label: "{discord-id}".into(),
-                value: "{discord-id}".into(),
-            },
-            SelectMenuOption {
-                default: false,
-                description: Some("Sets the nickname as the discord username".into()),
-                emoji: None,
-                label: "{discord-name}".into(),
-                value: "{discord-name}".into(),
-            },
-            SelectMenuOption {
-                default: false,
-                description: Some("Sets the nickname as the display name on Roblox".into()),
-                emoji: None,
-                label: "{display-name}".into(),
-                value: "{display-name}".into(),
-            },
-        ],
-        placeholder: None,
+    let template = match args.template {
+        Some(t) => Template(t),
+        None => {
+            let select_menu = SelectMenu {
+                custom_id: "template-reply".into(),
+                disabled: false,
+                max_values: Some(1),
+                min_values: Some(1),
+                options: vec![
+                    SelectMenuOption {
+                        default: false,
+                        description: Some("Sets the nickname as just the roblox username".into()),
+                        emoji: None,
+                        label: "{roblox-username}".into(),
+                        value: "{roblox-username}".into(),
+                    },
+                    SelectMenuOption {
+                        default: false,
+                        description: Some("Sets the nickname as the roblox id of the user".into()),
+                        emoji: None,
+                        label: "{roblox-id}".into(),
+                        value: "{roblox-id}".into(),
+                    },
+                    SelectMenuOption {
+                        default: false,
+                        description: Some("Sets the nickname as the discord id of the user".into()),
+                        emoji: None,
+                        label: "{discord-id}".into(),
+                        value: "{discord-id}".into(),
+                    },
+                    SelectMenuOption {
+                        default: false,
+                        description: Some("Sets the nickname as the discord username".into()),
+                        emoji: None,
+                        label: "{discord-name}".into(),
+                        value: "{discord-name}".into(),
+                    },
+                    SelectMenuOption {
+                        default: false,
+                        description: Some("Sets the nickname as the display name on Roblox".into()),
+                        emoji: None,
+                        label: "{display-name}".into(),
+                        value: "{display-name}".into(),
+                    },
+                ],
+                placeholder: None,
+            };
+            await_template_reply(
+                "Enter the template you wish to set for the bind.\nSelect one of the below or enter your own.",
+                &ctx,
+                select_menu
+            )
+            .await?
+        }
     };
-    let template = await_template_reply(
-        "Enter the template you wish to set for the bind.\nSelect one of the below or enter your own.",
-        &ctx,
-        select_menu
-    )
-    .await?;
 
-    let priority = match await_reply("Enter the priority you wish to set for the bind.", &ctx)
-        .await?
-        .parse::<i64>()
-    {
-        Ok(p) => p,
-        Err(_) => {
-            let embed = EmbedBuilder::new()
-                .default_data()
-                .color(Color::Red as u32)
-                .title("Custom Bind Addition Failed")
-                .description("Expected priority to be a number")
-                .build()
-                .unwrap();
-            ctx.respond().embeds(vec![embed]).await?;
-            return Ok(());
+    let priority = match args.priority {
+        Some(p) => p.unwrap_or_default(),
+        None => {
+            match await_reply("Enter the priority you wish to set for the bind.", &ctx)
+            .await?
+            .parse::<i64>()
+            {   
+                Ok(p) => p,
+                Err(_) => {
+                    let embed = EmbedBuilder::new()
+                        .default_data()
+                        .color(Color::Red as u32)
+                        .title("Custom Bind Addition Failed")
+                        .description("Expected priority to be a number")
+                        .build()
+                        .unwrap();
+                    ctx.respond().embeds(vec![embed]).await?;
+                    return Ok(());
+                }
+            }
         }
     };
 
     let server_roles = ctx.bot.cache.roles(guild_id);
-    let discord_roles_str = await_reply("Enter the roles you wish to set for the bind.\nEnter `N/A` if you would not like to set roles. Please tag the roles to ensure the bot can recognize them.", &ctx).await?;
+    let discord_roles_str = match args.discord_roles {
+        Some(s) => s.unwrap_or_default(),
+        None => await_reply("Enter the roles you wish to set for the bind.\nEnter `N/A` if you would not like to set roles. Please tag the roles to ensure the bot can recognize them.", &ctx).await?
+    };
     let mut discord_roles = Vec::new();
     for role_str in discord_roles_str.split_ascii_whitespace() {
         if let Some(role_id) = parse_role(role_str) {
@@ -163,7 +255,7 @@ pub async fn custombinds_new_common(
     let id = binds.last().unwrap_or(&0) + 1;
     let bind = CustomBind {
         id,
-        code: code.clone(),
+        code: args.code.clone(),
         prefix: None,
         priority,
         command,

--- a/rowifi/src/commands/events/mod.rs
+++ b/rowifi/src/commands/events/mod.rs
@@ -10,7 +10,7 @@ use rowifi_models::guild::GuildType;
 use new::events_new;
 use reset::event_reset;
 use summary::event_summary;
-use types::{event_type, event_type_modify, event_type_new};
+use types::{event_type, event_type_disable, event_type_enable, event_type_modify, event_type_new};
 use view::{event_attendee, event_host, event_view};
 
 pub fn events_config(cmds: &mut Vec<Command>) {
@@ -26,12 +26,26 @@ pub fn events_config(cmds: &mut Vec<Command>) {
         .description("Command to modify an existing event type")
         .handler(event_type_modify);
 
+    let event_types_disable_cmd = Command::builder()
+        .level(RoLevel::Admin)
+        .names(&["disable"])
+        .description("Command to disable an event type. This prevents trainers from logging new events with this type")
+        .handler(event_type_disable);
+
+    let event_types_enable_cmd = Command::builder()
+        .level(RoLevel::Admin)
+        .names(&["enable"])
+        .description("Command to enable an event type for logging")
+        .handler(event_type_enable);
+
     let event_types_cmd = Command::builder()
         .level(RoLevel::Admin)
         .names(&["types", "type"])
         .description("Command to view the event types")
         .sub_command(event_types_new_cmd)
         .sub_command(event_types_modify_cmd)
+        .sub_command(event_types_disable_cmd)
+        .sub_command(event_types_enable_cmd)
         .handler(event_type);
 
     let events_new_cmd = Command::builder()

--- a/rowifi/src/commands/events/mod.rs
+++ b/rowifi/src/commands/events/mod.rs
@@ -1,4 +1,6 @@
 mod new;
+mod reset;
+mod summary;
 mod types;
 mod view;
 
@@ -6,6 +8,8 @@ use rowifi_framework::prelude::*;
 use rowifi_models::guild::GuildType;
 
 use new::events_new;
+use reset::event_reset;
+use summary::event_summary;
 use types::{event_type, event_type_modify, event_type_new};
 use view::{event_attendee, event_host, event_view};
 
@@ -54,6 +58,18 @@ pub fn events_config(cmds: &mut Vec<Command>) {
         .description("Command to view information about a specific event")
         .handler(event_view);
 
+    let events_reset_cmd = Command::builder()
+        .level(RoLevel::Admin)
+        .names(&["reset"])
+        .description("Command to reset the events subsystem")
+        .handler(event_reset);
+
+    let events_summary_cmd = Command::builder()
+        .level(RoLevel::Admin)
+        .names(&["summary"])
+        .description("Command to view the summary of all logged events")
+        .handler(event_summary);
+
     let events_cmd = Command::builder()
         .level(RoLevel::Admin)
         .names(&["event", "events"])
@@ -64,6 +80,8 @@ pub fn events_config(cmds: &mut Vec<Command>) {
         .sub_command(events_attendee_cmd)
         .sub_command(events_host_cmd)
         .sub_command(events_view_cmd)
+        .sub_command(events_reset_cmd)
+        .sub_command(events_summary_cmd)
         .handler(events);
     cmds.push(events_cmd);
 }

--- a/rowifi/src/commands/events/mod.rs
+++ b/rowifi/src/commands/events/mod.rs
@@ -38,6 +38,12 @@ pub fn events_config(cmds: &mut Vec<Command>) {
         .description("Command to enable an event type for logging")
         .handler(event_type_enable);
 
+    let event_types_view_cmd = Command::builder()
+        .level(RoLevel::Admin)
+        .names(&["view"])
+        .description("Command to view the event types")
+        .handler(event_type);
+
     let event_types_cmd = Command::builder()
         .level(RoLevel::Admin)
         .names(&["types", "type"])
@@ -46,6 +52,7 @@ pub fn events_config(cmds: &mut Vec<Command>) {
         .sub_command(event_types_modify_cmd)
         .sub_command(event_types_disable_cmd)
         .sub_command(event_types_enable_cmd)
+        .sub_command(event_types_view_cmd)
         .handler(event_type);
 
     let events_new_cmd = Command::builder()

--- a/rowifi/src/commands/events/new.rs
+++ b/rowifi/src/commands/events/new.rs
@@ -56,12 +56,9 @@ pub async fn events_new(ctx: CommandContext) -> CommandResult {
         placeholder: None,
     };
 
-    let message = ctx
-        .bot
-        .http
-        .create_message(ctx.channel_id)
+    let message_id = ctx
+        .respond()
         .content("Select an event type")
-        .unwrap()
         .components(vec![
             Component::ActionRow(ActionRow {
                 components: vec![Component::SelectMenu(select_menu.clone())],
@@ -77,12 +74,11 @@ pub async fn events_new(ctx: CommandContext) -> CommandResult {
                 })],
             }),
         ])
-        .unwrap()
         .await?;
 
     select_menu.disabled = true;
 
-    let message_id = message.id;
+    let message_id = message_id.unwrap();
     let author_id = ctx.author.id;
     let stream = ctx
         .bot
@@ -150,15 +146,7 @@ pub async fn events_new(ctx: CommandContext) -> CommandResult {
 
     let event_type_id = match event_type_id {
         Some(e) => e.parse().unwrap(),
-        None => {
-            ctx.bot
-                .http
-                .update_message(message.channel_id, message_id)
-                .components(None)
-                .unwrap()
-                .await?;
-            return Ok(());
-        }
+        None => return Ok(()),
     };
 
     let event_type = guild
@@ -183,12 +171,7 @@ pub async fn events_new(ctx: CommandContext) -> CommandResult {
             .description("The number of valid attendees was found to be zero")
             .build()
             .unwrap();
-        ctx.bot
-            .http
-            .create_message(ctx.channel_id)
-            .embeds(vec![embed])
-            .unwrap()
-            .await?;
+        ctx.respond().embeds(vec![embed]).await?;
         return Ok(());
     }
 
@@ -239,11 +222,6 @@ pub async fn events_new(ctx: CommandContext) -> CommandResult {
         ))
         .build()
         .unwrap();
-    ctx.bot
-        .http
-        .create_message(ctx.channel_id)
-        .embeds(vec![embed])
-        .unwrap()
-        .await?;
+    ctx.respond().embeds(vec![embed]).await?;
     Ok(())
 }

--- a/rowifi/src/commands/events/new.rs
+++ b/rowifi/src/commands/events/new.rs
@@ -38,13 +38,15 @@ pub async fn events_new(ctx: CommandContext) -> CommandResult {
 
     let mut options = Vec::new();
     for event_type in &guild.event_types {
-        options.push(SelectMenuOption {
-            default: false,
-            description: None,
-            emoji: None,
-            label: event_type.name.clone(),
-            value: event_type.id.to_string(),
-        });
+        if !event_type.disabled {
+            options.push(SelectMenuOption {
+                default: false,
+                description: None,
+                emoji: None,
+                label: event_type.name.clone(),
+                value: event_type.id.to_string(),
+            });
+        }
     }
     let mut select_menu = SelectMenu {
         custom_id: "event-new-select".into(),

--- a/rowifi/src/commands/events/new.rs
+++ b/rowifi/src/commands/events/new.rs
@@ -48,6 +48,19 @@ pub async fn events_new(ctx: CommandContext) -> CommandResult {
             });
         }
     }
+
+    if options.is_empty() {
+        let embed = EmbedBuilder::new()
+            .default_data()
+            .color(Color::Red as u32)
+            .title("Event Addition Failed")
+            .description("There are no event types or all event types are disabled")
+            .build()
+            .unwrap();
+        ctx.respond().embed(embed).await?;
+        return Ok(());
+    }
+
     let mut select_menu = SelectMenu {
         custom_id: "event-new-select".into(),
         disabled: false,
@@ -156,7 +169,11 @@ pub async fn events_new(ctx: CommandContext) -> CommandResult {
         .find(|e| e.id == event_type_id)
         .unwrap();
 
-    let attendees_str = await_reply("Enter the list of attendees in this event", &ctx).await?;
+    let attendees_str = await_reply(
+        "Enter the usernames of Roblox Users who attended this event",
+        &ctx,
+    )
+    .await?;
     let mut attendees = Vec::new();
     for attendee in attendees_str.split(|c| c == ' ' || c == ',') {
         if let Ok(Some(roblox_id)) = ctx.bot.roblox.get_user_from_username(attendee).await {

--- a/rowifi/src/commands/events/new.rs
+++ b/rowifi/src/commands/events/new.rs
@@ -4,7 +4,6 @@ use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use rowifi_framework::prelude::*;
 use rowifi_models::{events::EventLog, guild::GuildType};
 use std::time::Duration;
-use twilight_mention::Mention;
 
 pub async fn events_new(ctx: CommandContext) -> CommandResult {
     let guild_id = ctx.guild_id.unwrap();
@@ -208,7 +207,7 @@ pub async fn events_new(ctx: CommandContext) -> CommandResult {
 
     let value = format!(
         "Host: {}\nType: {}\nAttendees: {}",
-        ctx.author.id.mention(),
+        format!("<@{}>", ctx.author.id.0),
         event_type.name,
         new_event.attendees.len()
     );

--- a/rowifi/src/commands/events/reset.rs
+++ b/rowifi/src/commands/events/reset.rs
@@ -18,6 +18,22 @@ pub async fn event_reset(ctx: CommandContext) -> CommandResult {
         return Ok(());
     }
 
+    let confirmation = await_confirmation(
+        "Are you sure you would like to delete all logged events & reset all event types?",
+        &ctx,
+    )
+    .await?;
+    if !confirmation {
+        let embed = EmbedBuilder::new()
+            .default_data()
+            .color(Color::Red as u32)
+            .title("Reset was cancelled!")
+            .build()
+            .unwrap();
+        ctx.respond().embed(embed).await?;
+        return Ok(());
+    }
+
     let filter = doc! {"_id": guild.id};
     let update = doc! {"$set": {"EventCounter": 0, "EventTypes": []}};
     ctx.bot.database.modify_guild(filter, update).await?;

--- a/rowifi/src/commands/events/reset.rs
+++ b/rowifi/src/commands/events/reset.rs
@@ -1,0 +1,38 @@
+use mongodb::bson::{doc, Document};
+use rowifi_framework::prelude::*;
+use rowifi_models::guild::GuildType;
+
+pub async fn event_reset(ctx: CommandContext) -> CommandResult {
+    let guild_id = ctx.guild_id.unwrap();
+    let guild = ctx.bot.database.get_guild(guild_id.0).await?;
+
+    if guild.settings.guild_type != GuildType::Beta {
+        let embed = EmbedBuilder::new()
+            .default_data()
+            .color(Color::Red as u32)
+            .title("Command Failed")
+            .description("This module may only be used in Beta Tier Servers")
+            .build()
+            .unwrap();
+        ctx.respond().embed(embed).await?;
+        return Ok(());
+    }
+
+    let filter = doc! {"_id": guild.id};
+    let update = doc! {"$set": {"EventCounter": 0, "EventTypes": []}};
+    ctx.bot.database.modify_guild(filter, update).await?;
+
+    let client = ctx.bot.database.as_ref();
+    let events = client.database("Events").collection::<Document>("Logs");
+    let filter = doc! {"GuildId": guild.id};
+    let _res = events
+        .delete_many(filter, None)
+        .await
+        .map_err(|d| RoError::Database(d.into()))?;
+
+    ctx.respond()
+        .content("The event system has been reset successfully")
+        .await?;
+
+    Ok(())
+}

--- a/rowifi/src/commands/events/summary.rs
+++ b/rowifi/src/commands/events/summary.rs
@@ -1,0 +1,68 @@
+use chrono::{Duration as CDuration, Utc};
+use itertools::Itertools;
+use mongodb::bson::doc;
+use rowifi_framework::prelude::*;
+use rowifi_models::guild::GuildType;
+
+pub async fn event_summary(ctx: CommandContext) -> CommandResult {
+    let guild_id = ctx.guild_id.unwrap();
+    let guild = ctx.bot.database.get_guild(guild_id.0).await?;
+
+    if guild.settings.guild_type != GuildType::Beta {
+        let embed = EmbedBuilder::new()
+            .default_data()
+            .color(Color::Red as u32)
+            .title("Command Failed")
+            .description("This module may only be used in Beta Tier Servers")
+            .build()
+            .unwrap();
+        ctx.respond().embed(embed).await?;
+        return Ok(());
+    }
+
+    let pipeline = vec![doc! {"$match": {"GuildId": guild_id.0 as i64}}];
+    let events = ctx.bot.database.get_events(pipeline).await?;
+
+    let mut embed = EmbedBuilder::new().default_data().title("Events Summary");
+
+    let event_groups = events
+        .iter()
+        .sorted_unstable_by_key(|e| e.event_type)
+        .group_by(|e| e.event_type);
+    for event_group in &event_groups {
+        let event_name = guild
+            .event_types
+            .iter()
+            .find(|e| e.id == event_group.0)
+            .unwrap();
+
+        let all_events = event_group.1.collect::<Vec<_>>();
+        let total = all_events.len();
+        let last_30_days = all_events
+            .iter()
+            .filter(|e| (Utc::now() - e.timestamp.to_chrono()) <= CDuration::days(30))
+            .count();
+        let last_7_days = all_events
+            .iter()
+            .filter(|e| (Utc::now() - e.timestamp.to_chrono()) <= CDuration::weeks(1))
+            .count();
+        let last_24_hours = all_events
+            .iter()
+            .filter(|e| (Utc::now() - e.timestamp.to_chrono()) <= CDuration::hours(24))
+            .count();
+
+        embed = embed.field(
+            EmbedFieldBuilder::new(
+                &event_name.name,
+                format!(
+                    "Total Events Hosted: {}\nHosted in last 30 days: {}\nHosted in 7 days: {}\nHosted in last 24 hours: {}",
+                    total, last_30_days, last_7_days, last_24_hours
+                )
+            )
+        );
+    }
+
+    ctx.respond().embed(embed.build().unwrap()).await?;
+
+    Ok(())
+}

--- a/rowifi/src/commands/events/types.rs
+++ b/rowifi/src/commands/events/types.rs
@@ -68,6 +68,7 @@ pub async fn event_type_new(ctx: CommandContext, args: EventTypeArguments) -> Co
         id: event_id,
         name: event_name.to_string(),
         xp: 0,
+        disabled: false,
     };
     let event_bson = to_bson(&event_type)?;
 
@@ -130,6 +131,120 @@ pub async fn event_type_modify(ctx: CommandContext, args: EventTypeArguments) ->
 
     let name = format!("Event Type Id: {}", event.id);
     let desc = format!("Name: {} -> {}", event.name.clone(), event_name);
+    let embed = EmbedBuilder::new()
+        .default_data()
+        .color(Color::DarkGreen as u32)
+        .title("Event Type Modification Successful")
+        .field(EmbedFieldBuilder::new(name, desc))
+        .build()
+        .unwrap();
+    ctx.respond().embed(embed).await?;
+    Ok(())
+}
+
+#[derive(FromArgs)]
+pub struct DisableArguments {
+    #[arg(help = "The event id to disable")]
+    pub event_id: i64,
+}
+
+pub async fn event_type_disable(ctx: CommandContext, args: DisableArguments) -> CommandResult {
+    let guild_id = ctx.guild_id.unwrap();
+    let guild = ctx.bot.database.get_guild(guild_id.0).await?;
+
+    if guild.settings.guild_type != GuildType::Beta {
+        let embed = EmbedBuilder::new()
+            .default_data()
+            .color(Color::Red as u32)
+            .title("Command Failed")
+            .description("This module may only be used in Beta Tier Servers")
+            .build()
+            .unwrap();
+        ctx.respond().embed(embed).await?;
+        return Ok(());
+    }
+
+    let event_id = args.event_id;
+    let event_type_index = match guild.event_types.iter().position(|e| e.id == event_id) {
+        Some(i) => i,
+        None => {
+            let embed = EmbedBuilder::new()
+                .default_data()
+                .color(Color::Red as u32)
+                .title("Event Type Modification Failed")
+                .description(format!("An event type with id {} does not exist", event_id))
+                .build()
+                .unwrap();
+            ctx.respond().embed(embed).await?;
+            return Ok(());
+        }
+    };
+    let event = &guild.event_types[event_type_index];
+
+    let filter = doc! {"_id": guild_id.0 as i64};
+    let index_str = format!("EventTypes.{}.Disabled", event_type_index);
+    let update = doc! {"$set": {index_str: true}};
+    ctx.bot.database.modify_guild(filter, update).await?;
+
+    let name = format!("Event Type Id: {}", event.id);
+    let desc = format!("Disabled: {} -> {}", event.disabled, true);
+    let embed = EmbedBuilder::new()
+        .default_data()
+        .color(Color::DarkGreen as u32)
+        .title("Event Type Modification Successful")
+        .field(EmbedFieldBuilder::new(name, desc))
+        .build()
+        .unwrap();
+    ctx.respond().embed(embed).await?;
+    Ok(())
+}
+
+#[derive(FromArgs)]
+pub struct EnableArguments {
+    #[arg(help = "The event id to enable")]
+    pub event_id: i64,
+}
+
+pub async fn event_type_enable(ctx: CommandContext, args: EnableArguments) -> CommandResult {
+    let guild_id = ctx.guild_id.unwrap();
+    let guild = ctx.bot.database.get_guild(guild_id.0).await?;
+
+    if guild.settings.guild_type != GuildType::Beta {
+        let embed = EmbedBuilder::new()
+            .default_data()
+            .color(Color::Red as u32)
+            .title("Command Failed")
+            .description("This module may only be used in Beta Tier Servers")
+            .build()
+            .unwrap();
+        ctx.respond().embed(embed).await?;
+        return Ok(());
+    }
+
+    let event_id = args.event_id;
+    let event_type_index = match guild.event_types.iter().position(|e| e.id == event_id) {
+        Some(i) => i,
+        None => {
+            let embed = EmbedBuilder::new()
+                .default_data()
+                .color(Color::Red as u32)
+                .title("Event Type Modification Failed")
+                .description(format!("An event type with id {} does not exist", event_id))
+                .build()
+                .unwrap();
+            ctx.respond().embed(embed).await?;
+            return Ok(());
+        }
+    };
+    let event = &guild.event_types[event_type_index];
+
+    let filter = doc! {"_id": guild_id.0 as i64};
+    let index_str = format!("EventTypes.{}.Disabled", event_type_index);
+    let update = doc! {"$set": {index_str: false}};
+    ctx.bot.database.modify_guild(filter, update).await?;
+
+    let name = format!("Event Type Id: {}", event.id);
+    let desc = format!("Disabled: {} -> {}", event.disabled, true);
     let embed = EmbedBuilder::new()
         .default_data()
         .color(Color::DarkGreen as u32)

--- a/rowifi/src/commands/events/types.rs
+++ b/rowifi/src/commands/events/types.rs
@@ -244,7 +244,7 @@ pub async fn event_type_enable(ctx: CommandContext, args: EnableArguments) -> Co
     ctx.bot.database.modify_guild(filter, update).await?;
 
     let name = format!("Event Type Id: {}", event.id);
-    let desc = format!("Disabled: {} -> {}", event.disabled, true);
+    let desc = format!("Disabled: {} -> {}", event.disabled, false);
     let embed = EmbedBuilder::new()
         .default_data()
         .color(Color::DarkGreen as u32)

--- a/rowifi/src/commands/events/types.rs
+++ b/rowifi/src/commands/events/types.rs
@@ -71,7 +71,7 @@ pub async fn event_type_new(ctx: CommandContext, args: EventTypeArguments) -> Co
     };
     let event_bson = to_bson(&event_type)?;
 
-    let filter = doc! {"_id": guild_id.0};
+    let filter = doc! {"_id": guild_id.0 as i64};
     let update = doc! {"$push": {"EventTypes": event_bson}};
 
     ctx.bot.database.modify_guild(filter, update).await?;
@@ -123,7 +123,7 @@ pub async fn event_type_modify(ctx: CommandContext, args: EventTypeArguments) ->
     };
     let event = &guild.event_types[event_type_index];
 
-    let filter = doc! {"_id": guild_id.0};
+    let filter = doc! {"_id": guild_id.0 as i64};
     let index_str = format!("EventTypes.{}.Name", event_type_index);
     let update = doc! {"$set": {index_str: event_name.clone()}};
     ctx.bot.database.modify_guild(filter, update).await?;

--- a/rowifi/src/commands/events/view.rs
+++ b/rowifi/src/commands/events/view.rs
@@ -90,7 +90,7 @@ pub async fn event_attendee(ctx: CommandContext, args: EventAttendeeArguments) -
             let host = ctx
                 .bot
                 .roblox
-                .get_user(RobloxUserId(event.host_id as u64))
+                .get_user(RobloxUserId(event.host_id as u64), false)
                 .await?;
             let desc = format!(
                 "Event Type: {}\nHost: {}\nTimestamp:{}",
@@ -192,7 +192,7 @@ pub async fn event_host(ctx: CommandContext, args: EventHostArguments) -> Comman
             let host = ctx
                 .bot
                 .roblox
-                .get_user(RobloxUserId(event.host_id as u64))
+                .get_user(RobloxUserId(event.host_id as u64), false)
                 .await?;
             let desc = format!(
                 "Event Type: {}\nHost: {}\nTimestamp:{}",
@@ -258,11 +258,15 @@ pub async fn event_view(ctx: CommandContext, args: EventViewArguments) -> Comman
     let host = ctx
         .bot
         .roblox
-        .get_user(RobloxUserId(event.host_id as u64))
+        .get_user(RobloxUserId(event.host_id as u64), false)
         .await?;
     let mut attendees = Vec::new();
     for a in &event.attendees {
-        let roblox_name = ctx.bot.roblox.get_user(RobloxUserId(*a as u64)).await?;
+        let roblox_name = ctx
+            .bot
+            .roblox
+            .get_user(RobloxUserId(*a as u64), false)
+            .await?;
         attendees.push(roblox_name);
     }
 

--- a/rowifi/src/commands/events/view.rs
+++ b/rowifi/src/commands/events/view.rs
@@ -62,7 +62,7 @@ pub async fn event_attendee(ctx: CommandContext, args: EventAttendeeArguments) -
     };
 
     let pipeline = vec![
-        doc! {"$match": {"GuildId": guild_id.0}},
+        doc! {"$match": {"GuildId": guild_id.0 as i64}},
         doc! {"$sort": {"Timestamp": -1}},
         doc! {"$unwind": "$Attendees"},
         doc! {"$match": {"Attendees": roblox_id}},
@@ -156,7 +156,7 @@ pub async fn event_host(ctx: CommandContext, args: EventHostArguments) -> Comman
     };
 
     let pipeline = vec![
-        doc! {"$match": {"GuildId": guild_id.0}},
+        doc! {"$match": {"GuildId": guild_id.0 as i64}},
         doc! {"$match": {"HostId": roblox_id}},
         doc! {"$sort": {"Timestamp": -1}},
         doc! {"$limit": 12},
@@ -215,7 +215,7 @@ pub async fn event_view(ctx: CommandContext, args: EventViewArguments) -> Comman
     }
 
     let event_id = args.event_id;
-    let pipeline = vec![doc! {"$match": {"GuildId": guild_id.0, "GuildEventId": event_id}}];
+    let pipeline = vec![doc! {"$match": {"GuildId": guild_id.0 as i64, "GuildEventId": event_id}}];
     let events = ctx.bot.database.get_events(pipeline).await?;
     if events.is_empty() {
         let embed = EmbedBuilder::new()

--- a/rowifi/src/commands/events/view.rs
+++ b/rowifi/src/commands/events/view.rs
@@ -93,10 +93,10 @@ pub async fn event_attendee(ctx: CommandContext, args: EventAttendeeArguments) -
                 .get_user(RobloxUserId(event.host_id as u64), false)
                 .await?;
             let desc = format!(
-                "Event Type: {}\nHost: {}\nTimestamp:{}",
+                "Event Type: {}\nHost: {}\nTimestamp: <t:{}:f>",
                 event_type.name,
                 host.name,
-                DateTime::<Utc>::from(event.timestamp).to_rfc3339()
+                event.timestamp.to_chrono().timestamp()
             );
 
             embed = embed.field(EmbedFieldBuilder::new(name, desc).inline());
@@ -195,10 +195,10 @@ pub async fn event_host(ctx: CommandContext, args: EventHostArguments) -> Comman
                 .get_user(RobloxUserId(event.host_id as u64), false)
                 .await?;
             let desc = format!(
-                "Event Type: {}\nHost: {}\nTimestamp:{}",
+                "Event Type: {}\nHost: {}\nTimestamp: <t:{}:f>",
                 event_type.name,
                 host.name,
-                DateTime::<Utc>::from(event.timestamp).to_rfc3339()
+                event.timestamp.to_chrono().timestamp()
             );
 
             embed = embed.field(EmbedFieldBuilder::new(name, desc).inline());

--- a/rowifi/src/commands/group/bind.rs
+++ b/rowifi/src/commands/group/bind.rs
@@ -5,11 +5,11 @@ use regex::Regex;
 use rowifi_framework::prelude::*;
 use rowifi_models::{
     bind::{AssetBind, AssetType, GroupBind, RankBind, Template},
+    discord::id::{GuildId, RoleId},
     guild::RoGuild,
     roblox::{group::PartialRank, id::GroupId},
 };
 use std::str::FromStr;
-use twilight_model::id::{GuildId, RoleId};
 
 use crate::commands::{custombinds::new::custombinds_new_common, log_rankbind};
 

--- a/rowifi/src/commands/group/bind.rs
+++ b/rowifi/src/commands/group/bind.rs
@@ -11,7 +11,9 @@ use rowifi_models::{
 };
 use std::str::FromStr;
 
-use crate::commands::{custombinds::new::custombinds_new_common, log_rankbind, new::CustombindsNewArguments};
+use crate::commands::{
+    custombinds::new::custombinds_new_common, log_rankbind, new::CustombindsNewArguments,
+};
 
 lazy_static! {
     pub static ref TEMPLATE_REGEX: Regex = Regex::new(r"\[(.*?)\]").unwrap();
@@ -138,12 +140,18 @@ pub async fn bind(ctx: CommandContext) -> CommandResult {
 async fn bind_custom(ctx: CommandContext, guild_id: GuildId, guild: RoGuild) -> CommandResult {
     let code = await_reply("Enter the code for this bind.", &ctx).await?;
 
-    custombinds_new_common(ctx, guild_id, guild, CustombindsNewArguments {
-        code,
-        template: None,
-        priority: None,
-        discord_roles: None
-    }).await
+    custombinds_new_common(
+        ctx,
+        guild_id,
+        guild,
+        CustombindsNewArguments {
+            code,
+            template: None,
+            priority: None,
+            discord_roles: None,
+        },
+    )
+    .await
 }
 
 async fn bind_asset(ctx: CommandContext, guild_id: GuildId, guild: RoGuild) -> CommandResult {

--- a/rowifi/src/commands/group/bind.rs
+++ b/rowifi/src/commands/group/bind.rs
@@ -71,6 +71,7 @@ pub async fn bind(ctx: CommandContext) -> CommandResult {
 
     select_menu.disabled = true;
 
+    ctx.bot.ignore_message_components.insert(message_id);
     let mut bind_type = None;
     while let Some(Ok(event)) = stream.next().await {
         if let Event::InteractionCreate(interaction) = &event {
@@ -117,6 +118,7 @@ pub async fn bind(ctx: CommandContext) -> CommandResult {
             }
         }
     }
+    ctx.bot.ignore_message_components.remove(&message_id);
 
     let bind_type = match bind_type {
         Some(b) => b,
@@ -195,6 +197,7 @@ async fn bind_asset(ctx: CommandContext, guild_id: GuildId, guild: RoGuild) -> C
 
     select_menu.disabled = true;
 
+    ctx.bot.ignore_message_components.insert(message_id);
     let mut asset_type = None;
     while let Some(Ok(event)) = stream.next().await {
         if let Event::InteractionCreate(interaction) = &event {
@@ -238,6 +241,7 @@ async fn bind_asset(ctx: CommandContext, guild_id: GuildId, guild: RoGuild) -> C
             }
         }
     }
+    ctx.bot.ignore_message_components.remove(&message_id);
 
     let asset_type = match asset_type {
         Some(s) => match AssetType::from_arg(&s) {

--- a/rowifi/src/commands/group/bind.rs
+++ b/rowifi/src/commands/group/bind.rs
@@ -173,19 +173,15 @@ async fn bind_asset(ctx: CommandContext, guild_id: GuildId, guild: RoGuild) -> C
         placeholder: None,
     };
 
-    let message = ctx
-        .bot
-        .http
-        .create_message(ctx.channel_id)
+    let message_id = ctx
+        .respond()
         .content("Select the type of asset to bind:")
-        .unwrap()
         .components(vec![Component::ActionRow(ActionRow {
             components: vec![Component::SelectMenu(select_menu.clone())],
         })])
-        .unwrap()
         .await?;
 
-    let message_id = message.id;
+    let message_id = message_id.unwrap();
     let author_id = ctx.author.id;
 
     let stream = ctx
@@ -264,12 +260,7 @@ async fn bind_asset(ctx: CommandContext, guild_id: GuildId, guild: RoGuild) -> C
                 .description("Expected asset id to be a number")
                 .build()
                 .unwrap();
-            ctx.bot
-                .http
-                .create_message(ctx.channel_id)
-                .embeds(vec![embed])
-                .unwrap()
-                .await?;
+            ctx.respond().embeds(vec![embed]).await?;
             return Ok(());
         }
     };
@@ -338,12 +329,7 @@ async fn bind_asset(ctx: CommandContext, guild_id: GuildId, guild: RoGuild) -> C
                 .description("Expected priority to be a number")
                 .build()
                 .unwrap();
-            ctx.bot
-                .http
-                .create_message(ctx.channel_id)
-                .embeds(vec![embed])
-                .unwrap()
-                .await?;
+            ctx.respond().embeds(vec![embed]).await?;
             return Ok(());
         }
     };
@@ -390,12 +376,7 @@ async fn bind_asset(ctx: CommandContext, guild_id: GuildId, guild: RoGuild) -> C
         .field(EmbedFieldBuilder::new(name.clone(), value.clone()))
         .build()
         .unwrap();
-    ctx.bot
-        .http
-        .create_message(ctx.channel_id)
-        .embeds(vec![embed])
-        .unwrap()
-        .await?;
+    ctx.respond().embeds(vec![embed]).await?;
 
     let log_embed = EmbedBuilder::new()
         .default_data()
@@ -423,12 +404,7 @@ async fn bind_group(ctx: CommandContext, guild_id: GuildId, guild: RoGuild) -> C
                 .description("Expected the group id to be a number")
                 .build()
                 .unwrap();
-            ctx.bot
-                .http
-                .create_message(ctx.channel_id)
-                .embeds(vec![embed])
-                .unwrap()
-                .await?;
+            ctx.respond().embeds(vec![embed]).await?;
             return Ok(());
         }
     };
@@ -443,12 +419,7 @@ async fn bind_group(ctx: CommandContext, guild_id: GuildId, guild: RoGuild) -> C
                 .description(format!("Group with Id {} does not exist", group_id))
                 .build()
                 .unwrap();
-            ctx.bot
-                .http
-                .create_message(ctx.channel_id)
-                .embeds(vec![embed])
-                .unwrap()
-                .await?;
+            ctx.respond().embeds(vec![embed]).await?;
             return Ok(());
         }
     };
@@ -488,12 +459,7 @@ async fn bind_group(ctx: CommandContext, guild_id: GuildId, guild: RoGuild) -> C
             .description("There were no ranks found associated with the entered ones")
             .build()
             .unwrap();
-        ctx.bot
-            .http
-            .create_message(ctx.channel_id)
-            .embeds(vec![embed])
-            .unwrap()
-            .await?;
+        ctx.respond().embeds(vec![embed]).await?;
         return Ok(());
     }
 
@@ -571,12 +537,7 @@ async fn bind_group(ctx: CommandContext, guild_id: GuildId, guild: RoGuild) -> C
                 .description("Expected priority to be a number")
                 .build()
                 .unwrap();
-            ctx.bot
-                .http
-                .create_message(ctx.channel_id)
-                .embeds(vec![embed])
-                .unwrap()
-                .await?;
+            ctx.respond().embeds(vec![embed]).await?;
             return Ok(());
         }
     };

--- a/rowifi/src/commands/group/bind.rs
+++ b/rowifi/src/commands/group/bind.rs
@@ -11,7 +11,7 @@ use rowifi_models::{
 };
 use std::str::FromStr;
 
-use crate::commands::{custombinds::new::custombinds_new_common, log_rankbind};
+use crate::commands::{custombinds::new::custombinds_new_common, log_rankbind, new::CustombindsNewArguments};
 
 lazy_static! {
     pub static ref TEMPLATE_REGEX: Regex = Regex::new(r"\[(.*?)\]").unwrap();
@@ -138,7 +138,12 @@ pub async fn bind(ctx: CommandContext) -> CommandResult {
 async fn bind_custom(ctx: CommandContext, guild_id: GuildId, guild: RoGuild) -> CommandResult {
     let code = await_reply("Enter the code for this bind.", &ctx).await?;
 
-    custombinds_new_common(ctx, guild_id, guild, code).await
+    custombinds_new_common(ctx, guild_id, guild, CustombindsNewArguments {
+        code,
+        template: None,
+        priority: None,
+        discord_roles: None
+    }).await
 }
 
 async fn bind_asset(ctx: CommandContext, guild_id: GuildId, guild: RoGuild) -> CommandResult {

--- a/rowifi/src/commands/group/reset.rs
+++ b/rowifi/src/commands/group/reset.rs
@@ -3,6 +3,23 @@ use rowifi_models::guild::RoGuild;
 
 pub async fn reset(ctx: CommandContext) -> CommandResult {
     let guild_id = ctx.guild_id.unwrap();
+
+    let confirmation = await_confirmation(
+        "Are you sure you would like to reset all binds & configurations?",
+        &ctx,
+    )
+    .await?;
+    if !confirmation {
+        let embed = EmbedBuilder::new()
+            .default_data()
+            .color(Color::Red as u32)
+            .title("Reset was cancelled!")
+            .build()
+            .unwrap();
+        ctx.respond().embed(embed).await?;
+        return Ok(());
+    }
+
     let guild = ctx.bot.database.get_guild(guild_id.0).await?;
     let guild = RoGuild {
         id: guild_id.0 as i64,

--- a/rowifi/src/commands/group/serverinfo.rs
+++ b/rowifi/src/commands/group/serverinfo.rs
@@ -1,5 +1,4 @@
 use rowifi_framework::prelude::*;
-use twilight_embed_builder::EmbedFieldBuilder;
 
 pub async fn serverinfo(ctx: CommandContext) -> CommandResult {
     let guild_id = ctx.guild_id.unwrap();

--- a/rowifi/src/commands/group/update_mul.rs
+++ b/rowifi/src/commands/group/update_mul.rs
@@ -18,12 +18,7 @@ pub async fn update_all(ctx: CommandContext) -> CommandResult {
             .description("This command may only be used in Premium Servers")
             .build()
             .unwrap();
-        ctx.bot
-            .http
-            .create_message(ctx.channel_id)
-            .embeds(vec![embed])
-            .unwrap()
-            .await?;
+        ctx.respond().embeds(vec![embed]).await?;
         return Ok(());
     }
 
@@ -49,7 +44,7 @@ pub async fn update_all(ctx: CommandContext) -> CommandResult {
         let req = RequestGuildMembers::builder(server.id).query("", None);
         let shard_id = (guild_id.0 >> 22) % ctx.bot.total_shards;
         if ctx.bot.cluster.command(shard_id, &req).await.is_err() {
-            ctx.bot.http.create_message(ctx.channel_id).content("There was an issue in requesting the server members. Please try again. If the issue persists, please contact our support server.").unwrap().await?;
+            ctx.respond().content("There was an issue in requesting the server members. Please try again. If the issue persists, please contact our support server.").await?;
             return Ok(());
         }
         let _ = ctx
@@ -139,12 +134,7 @@ pub async fn update_role(ctx: CommandContext, args: UpdateMultipleArguments) -> 
             .description("This command may only be used in Premium Servers")
             .build()
             .unwrap();
-        ctx.bot
-            .http
-            .create_message(ctx.channel_id)
-            .embeds(vec![embed])
-            .unwrap()
-            .await?;
+        ctx.respond().embeds(vec![embed]).await?;
         return Ok(());
     }
 
@@ -180,7 +170,7 @@ pub async fn update_role(ctx: CommandContext, args: UpdateMultipleArguments) -> 
         let req = RequestGuildMembers::builder(server.id).query("", None);
         let shard_id = (guild_id.0 >> 22) % ctx.bot.total_shards;
         if ctx.bot.cluster.command(shard_id, &req).await.is_err() {
-            ctx.bot.http.create_message(ctx.channel_id).content("There was an issue in requesting the server members. Please try again. If the issue persists, please contact our support server.").unwrap().await?;
+            ctx.respond().content("There was an issue in requesting the server members. Please try again. If the issue persists, please contact our support server.").await?;
             return Ok(());
         }
         let _ = ctx

--- a/rowifi/src/commands/group/update_mul.rs
+++ b/rowifi/src/commands/group/update_mul.rs
@@ -1,11 +1,14 @@
 use rowifi_framework::prelude::*;
-use rowifi_models::{guild::GuildType, roblox::id::UserId as RobloxUserId};
+use rowifi_models::{
+    discord::{
+        gateway::payload::RequestGuildMembers,
+        id::{RoleId, UserId},
+    },
+    guild::GuildType,
+    roblox::id::UserId as RobloxUserId,
+};
 use std::sync::atomic::Ordering;
 use twilight_gateway::Event;
-use twilight_model::{
-    gateway::payload::RequestGuildMembers,
-    id::{RoleId, UserId},
-};
 
 pub async fn update_all(ctx: CommandContext) -> CommandResult {
     let guild_id = ctx.guild_id.unwrap();

--- a/rowifi/src/commands/group/update_mul.rs
+++ b/rowifi/src/commands/group/update_mul.rs
@@ -93,7 +93,8 @@ pub async fn update_all(ctx: CommandContext) -> CommandResult {
                     tracing::trace!(id = user.discord_id, "Mass Update for member");
                     let name = member.user.name.clone();
                     if let Ok((added_roles, removed_roles, disc_nick)) = c
-                        .update_user(member, user, &server, &guild, &guild_roles)
+                        .bot
+                        .update_user(member, user, &server, &guild, &guild_roles, false)
                         .await
                     {
                         if !added_roles.is_empty() || !removed_roles.is_empty() {
@@ -222,7 +223,8 @@ pub async fn update_role(ctx: CommandContext, args: UpdateMultipleArguments) -> 
                     tracing::trace!(id = user.discord_id, "Mass Update for member");
                     let name = member.user.name.clone();
                     if let Ok((added_roles, removed_roles, disc_nick)) = c
-                        .update_user(member, user, &server, &guild, &guild_roles)
+                        .bot
+                        .update_user(member, user, &server, &guild, &guild_roles, false)
                         .await
                     {
                         if !added_roles.is_empty() || !removed_roles.is_empty() {

--- a/rowifi/src/commands/group/update_mul.rs
+++ b/rowifi/src/commands/group/update_mul.rs
@@ -43,7 +43,7 @@ pub async fn update_all(ctx: CommandContext) -> CommandResult {
         .cache
         .members(guild_id)
         .into_iter()
-        .map(|m| m.0)
+        .map(|m| m.0 as i64)
         .collect::<Vec<_>>();
     if (members.len() as i64) < server.member_count.load(Ordering::SeqCst) / 2 {
         let req = RequestGuildMembers::builder(server.id).query("", None);
@@ -69,7 +69,7 @@ pub async fn update_all(ctx: CommandContext) -> CommandResult {
             .cache
             .members(guild_id)
             .into_iter()
-            .map(|m| m.0)
+            .map(|m| m.0 as i64)
             .collect::<Vec<_>>();
     }
     let users = ctx
@@ -174,7 +174,7 @@ pub async fn update_role(ctx: CommandContext, args: UpdateMultipleArguments) -> 
         .cache
         .members(guild_id)
         .into_iter()
-        .map(|m| m.0)
+        .map(|m| m.0 as i64)
         .collect::<Vec<_>>();
     if (members.len() as i64) < server.member_count.load(Ordering::SeqCst) / 2 {
         let req = RequestGuildMembers::builder(server.id).query("", None);
@@ -200,7 +200,7 @@ pub async fn update_role(ctx: CommandContext, args: UpdateMultipleArguments) -> 
             .cache
             .members(guild_id)
             .into_iter()
-            .map(|m| m.0)
+            .map(|m| m.0 as i64)
             .collect::<Vec<_>>();
     }
     let users = ctx

--- a/rowifi/src/commands/groupbinds/delete.rs
+++ b/rowifi/src/commands/groupbinds/delete.rs
@@ -95,6 +95,7 @@ pub async fn groupbinds_delete(
         .timeout(Duration::from_secs(60));
     tokio::pin!(stream);
 
+    ctx.bot.ignore_message_components.insert(message_id);
     while let Some(Ok(event)) = stream.next().await {
         if let Event::InteractionCreate(interaction) = &event {
             if let Interaction::MessageComponent(message_component) = &interaction.0 {
@@ -134,7 +135,7 @@ pub async fn groupbinds_delete(
                         .embeds(vec![embed])
                         .await?;
 
-                    return Ok(());
+                    break;
                 }
                 let _ = ctx
                     .bot
@@ -156,22 +157,7 @@ pub async fn groupbinds_delete(
             }
         }
     }
+    ctx.bot.ignore_message_components.remove(&message_id);
 
-    if let Some(interaction_token) = &ctx.interaction_token {
-        ctx.bot
-            .http
-            .update_interaction_original(interaction_token)
-            .unwrap()
-            .components(None)
-            .unwrap()
-            .await?;
-    } else {
-        ctx.bot
-            .http
-            .update_message(ctx.channel_id, message_id)
-            .components(None)
-            .unwrap()
-            .await?;
-    }
     Ok(())
 }

--- a/rowifi/src/commands/groupbinds/mod.rs
+++ b/rowifi/src/commands/groupbinds/mod.rs
@@ -4,8 +4,6 @@ mod new;
 
 use itertools::Itertools;
 use rowifi_framework::prelude::*;
-use twilight_mention::Mention;
-use twilight_model::id::RoleId;
 
 pub use delete::groupbinds_delete;
 pub use modify::groupbinds_modify;
@@ -88,7 +86,7 @@ pub async fn groupbinds_view(ctx: CommandContext, _args: GroupbindsViewArguments
                 gb.priority,
                 gb.discord_roles
                     .iter()
-                    .map(|r| RoleId(*r as u64).mention().to_string())
+                    .map(|r| format!("<@&{}> ", r))
                     .collect::<String>()
             );
             embed = embed.field(EmbedFieldBuilder::new(name, desc).inline().build());

--- a/rowifi/src/commands/groupbinds/modify.rs
+++ b/rowifi/src/commands/groupbinds/modify.rs
@@ -113,11 +113,11 @@ async fn add_roles(
     guild: &RoGuild,
     bind_index: usize,
     roles: &str,
-) -> Result<Vec<u64>, RoError> {
+) -> Result<Vec<i64>, RoError> {
     let mut role_ids = Vec::new();
     for r in roles.split_ascii_whitespace() {
         if let Some(r) = parse_role(r) {
-            role_ids.push(r);
+            role_ids.push(r as i64);
         }
     }
     let filter = doc! {"_id": guild.id};
@@ -132,11 +132,11 @@ async fn remove_roles(
     guild: &RoGuild,
     bind_index: usize,
     roles: &str,
-) -> Result<Vec<u64>, RoError> {
+) -> Result<Vec<i64>, RoError> {
     let mut role_ids = Vec::new();
     for r in roles.split_ascii_whitespace() {
         if let Some(r) = parse_role(r) {
-            role_ids.push(r);
+            role_ids.push(r as i64);
         }
     }
     let filter = doc! {"_id": guild.id};

--- a/rowifi/src/commands/groupbinds/new.rs
+++ b/rowifi/src/commands/groupbinds/new.rs
@@ -1,8 +1,9 @@
 use mongodb::bson::{doc, to_bson};
 use rowifi_framework::prelude::*;
-use rowifi_models::bind::{GroupBind, Template};
-use twilight_mention::Mention;
-use twilight_model::id::RoleId;
+use rowifi_models::{
+    bind::{GroupBind, Template},
+    discord::id::RoleId,
+};
 
 #[derive(FromArgs)]
 pub struct GroupbindsNewArguments {
@@ -81,7 +82,7 @@ pub async fn groupbinds_new(ctx: CommandContext, args: GroupbindsNewArguments) -
         priority,
         bind.discord_roles
             .iter()
-            .map(|r| RoleId(*r as u64).mention().to_string())
+            .map(|r| format!("<@&{}> ", r))
             .collect::<String>()
     );
     let embed = EmbedBuilder::new()

--- a/rowifi/src/commands/groupbinds/new.rs
+++ b/rowifi/src/commands/groupbinds/new.rs
@@ -127,6 +127,7 @@ pub async fn groupbinds_new(ctx: CommandContext, args: GroupbindsNewArguments) -
         .timeout(Duration::from_secs(300));
     tokio::pin!(stream);
 
+    ctx.bot.ignore_message_components.insert(message_id);
     while let Some(Ok(event)) = stream.next().await {
         if let Event::InteractionCreate(interaction) = &event {
             if let Interaction::MessageComponent(message_component) = &interaction.0 {
@@ -165,7 +166,7 @@ pub async fn groupbinds_new(ctx: CommandContext, args: GroupbindsNewArguments) -
                         .embeds(vec![embed])
                         .await?;
 
-                    return Ok(());
+                    break;
                 }
                 let _ = ctx
                     .bot
@@ -187,23 +188,7 @@ pub async fn groupbinds_new(ctx: CommandContext, args: GroupbindsNewArguments) -
             }
         }
     }
-
-    if let Some(interaction_token) = &ctx.interaction_token {
-        ctx.bot
-            .http
-            .update_interaction_original(interaction_token)
-            .unwrap()
-            .components(None)
-            .unwrap()
-            .await?;
-    } else {
-        ctx.bot
-            .http
-            .update_message(ctx.channel_id, message_id)
-            .components(None)
-            .unwrap()
-            .await?;
-    }
+    ctx.bot.ignore_message_components.remove(&message_id);
 
     Ok(())
 }

--- a/rowifi/src/commands/premium/mod.rs
+++ b/rowifi/src/commands/premium/mod.rs
@@ -34,6 +34,12 @@ pub fn premium_config(cmds: &mut Vec<Command>) {
         .description("Command to transfer your premium to another account")
         .handler(premium_transfer);
 
+    let premium_view_cmd = Command::builder()
+        .level(RoLevel::Normal)
+        .names(&["view"])
+        .description("Command to view premium information about an user")
+        .handler(premium);
+
     let premium_cmd = Command::builder()
         .level(RoLevel::Normal)
         .names(&["premium"])
@@ -43,6 +49,7 @@ pub fn premium_config(cmds: &mut Vec<Command>) {
         .sub_command(premium_redeem_cmd)
         .sub_command(premium_remove_cmd)
         .sub_command(premium_transfer_cmd)
+        .sub_command(premium_view_cmd)
         .handler(premium);
 
     cmds.push(premium_cmd);

--- a/rowifi/src/commands/premium/mod.rs
+++ b/rowifi/src/commands/premium/mod.rs
@@ -3,8 +3,7 @@ mod redeem;
 mod transfer;
 
 use rowifi_framework::prelude::*;
-use rowifi_models::user::PremiumType;
-use twilight_model::id::UserId;
+use rowifi_models::{discord::id::UserId, user::PremiumType};
 
 use self::patreon::premium_patreon;
 use redeem::{premium_redeem, premium_remove};

--- a/rowifi/src/commands/premium/redeem.rs
+++ b/rowifi/src/commands/premium/redeem.rs
@@ -48,14 +48,14 @@ pub async fn premium_redeem(ctx: CommandContext) -> CommandResult {
 
     let guild = ctx.bot.database.get_guild(guild_id.0).await?;
 
-    let filter = doc! {"_id": guild_id.0};
+    let filter = doc! {"_id": guild_id.0 as i64};
     let update =
         doc! {"$set": {"Settings.Type": guild_type as i32, "Settings.AutoDetection": true}};
     ctx.bot.database.modify_guild(filter, update).await?;
 
     if !premium_user.discord_servers.contains(&(guild_id.0 as i64)) {
-        let filter2 = doc! {"_id": ctx.author.id.0};
-        let update2 = doc! {"$push": { "Servers": guild_id.0 }};
+        let filter2 = doc! {"_id": ctx.author.id.0 as i64};
+        let update2 = doc! {"$push": { "Servers": guild_id.0 as i64 }};
         ctx.bot.database.modify_premium(filter2, update2).await?;
     }
 
@@ -137,13 +137,13 @@ pub async fn premium_remove(ctx: CommandContext) -> CommandResult {
 
     ctx.bot.database.get_guild(guild_id.0).await?;
 
-    let filter = doc! {"_id": guild_id.0};
+    let filter = doc! {"_id": guild_id.0 as i64};
     let update =
         doc! {"$set": {"Settings.Type": GuildType::Normal as i32, "Settings.AutoDetection": false}};
     ctx.bot.database.modify_guild(filter, update).await?;
 
-    let filter2 = doc! {"_id": ctx.author.id.0};
-    let update2 = doc! {"$pull": { "Servers": guild_id.0 }};
+    let filter2 = doc! {"_id": ctx.author.id.0 as i64};
+    let update2 = doc! {"$pull": { "Servers": guild_id.0 as i64 }};
     ctx.bot.database.modify_premium(filter2, update2).await?;
 
     ctx.bot.admin_roles.remove(&guild_id);

--- a/rowifi/src/commands/premium/redeem.rs
+++ b/rowifi/src/commands/premium/redeem.rs
@@ -1,8 +1,10 @@
 use mongodb::bson::doc;
 use rowifi_framework::prelude::*;
-use rowifi_models::guild::GuildType;
+use rowifi_models::{
+    discord::{gateway::payload::RequestGuildMembers, id::RoleId},
+    guild::GuildType,
+};
 use std::env;
-use twilight_model::{gateway::payload::RequestGuildMembers, id::RoleId};
 
 pub async fn premium_redeem(ctx: CommandContext) -> CommandResult {
     let guild_id = ctx.guild_id.unwrap();

--- a/rowifi/src/commands/premium/transfer.rs
+++ b/rowifi/src/commands/premium/transfer.rs
@@ -1,6 +1,5 @@
 use rowifi_framework::prelude::*;
-use rowifi_models::user::PremiumUser;
-use twilight_model::id::UserId;
+use rowifi_models::{discord::id::UserId, user::PremiumUser};
 
 #[derive(FromArgs)]
 pub struct PremiumTransferArguments {

--- a/rowifi/src/commands/rankbinds/delete.rs
+++ b/rowifi/src/commands/rankbinds/delete.rs
@@ -114,6 +114,7 @@ pub async fn rankbinds_delete(ctx: CommandContext, args: RankBindsDelete) -> Com
         .timeout(Duration::from_secs(60));
     tokio::pin!(stream);
 
+    ctx.bot.ignore_message_components.insert(message_id);
     while let Some(Ok(event)) = stream.next().await {
         if let Event::InteractionCreate(interaction) = &event {
             if let Interaction::MessageComponent(message_component) = &interaction.0 {
@@ -153,7 +154,7 @@ pub async fn rankbinds_delete(ctx: CommandContext, args: RankBindsDelete) -> Com
                         .embeds(vec![embed])
                         .await?;
 
-                    return Ok(());
+                    break;
                 }
                 let _ = ctx
                     .bot
@@ -175,23 +176,7 @@ pub async fn rankbinds_delete(ctx: CommandContext, args: RankBindsDelete) -> Com
             }
         }
     }
-
-    if let Some(interaction_token) = &ctx.interaction_token {
-        ctx.bot
-            .http
-            .update_interaction_original(interaction_token)
-            .unwrap()
-            .components(None)
-            .unwrap()
-            .await?;
-    } else {
-        ctx.bot
-            .http
-            .update_message(ctx.channel_id, message_id)
-            .components(None)
-            .unwrap()
-            .await?;
-    }
+    ctx.bot.ignore_message_components.remove(&message_id);
 
     Ok(())
 }

--- a/rowifi/src/commands/rankbinds/mod.rs
+++ b/rowifi/src/commands/rankbinds/mod.rs
@@ -4,9 +4,6 @@ mod new;
 
 use itertools::Itertools;
 use rowifi_framework::prelude::*;
-use twilight_embed_builder::EmbedFieldBuilder;
-use twilight_mention::Mention;
-use twilight_model::id::RoleId;
 
 pub use delete::*;
 pub use modify::*;
@@ -95,7 +92,7 @@ pub async fn rankbinds_view(ctx: CommandContext, _args: RankbindArguments) -> Re
                     rb.priority,
                     rb.discord_roles
                         .iter()
-                        .map(|r| RoleId(*r as u64).mention().to_string())
+                        .map(|r| format!("<@&{}> ", r))
                         .collect::<String>()
                 );
                 embed = embed.field(EmbedFieldBuilder::new(name, desc).inline().build());

--- a/rowifi/src/commands/rankbinds/modify.rs
+++ b/rowifi/src/commands/rankbinds/modify.rs
@@ -1,7 +1,6 @@
 use mongodb::bson::doc;
 use rowifi_framework::prelude::*;
 use rowifi_models::{guild::RoGuild, roblox::id::GroupId};
-use twilight_embed_builder::EmbedFieldBuilder;
 
 use super::new::PREFIX_REGEX;
 

--- a/rowifi/src/commands/rankbinds/modify.rs
+++ b/rowifi/src/commands/rankbinds/modify.rs
@@ -184,11 +184,11 @@ async fn add_roles(
     guild: &RoGuild,
     bind_index: usize,
     roles: &str,
-) -> Result<Vec<u64>, RoError> {
+) -> Result<Vec<i64>, RoError> {
     let mut role_ids = Vec::new();
     for r in roles.split_ascii_whitespace() {
         if let Some(r) = parse_role(r) {
-            role_ids.push(r);
+            role_ids.push(r as i64);
         }
     }
     let filter = doc! {"_id": guild.id};
@@ -203,11 +203,11 @@ async fn remove_roles(
     guild: &RoGuild,
     bind_index: usize,
     roles: &str,
-) -> Result<Vec<u64>, RoError> {
+) -> Result<Vec<i64>, RoError> {
     let mut role_ids = Vec::new();
     for r in roles.split_ascii_whitespace() {
         if let Some(r) = parse_role(r) {
-            role_ids.push(r);
+            role_ids.push(r as i64);
         }
     }
     let filter = doc! {"_id": guild.id};

--- a/rowifi/src/commands/rankbinds/new.rs
+++ b/rowifi/src/commands/rankbinds/new.rs
@@ -3,12 +3,11 @@ use lazy_static::lazy_static;
 use mongodb::bson::doc;
 use regex::Regex;
 use rowifi_framework::prelude::*;
+use rowifi_models::discord::id::RoleId;
 use rowifi_models::{
     bind::{RankBind, Template},
     roblox::id::GroupId,
 };
-use twilight_embed_builder::EmbedFieldBuilder;
-use twilight_model::id::RoleId;
 
 #[derive(Debug, FromArgs)]
 pub struct NewRankbind {

--- a/rowifi/src/commands/settings/admin.rs
+++ b/rowifi/src/commands/settings/admin.rs
@@ -127,7 +127,7 @@ pub async fn admin_remove(
     let mut role_ids = Vec::new();
     for r in discord_roles.split_ascii_whitespace() {
         if let Some(r) = parse_role(r) {
-            role_ids.push(r);
+            role_ids.push(r as i64);
         }
     }
 
@@ -139,7 +139,7 @@ pub async fn admin_remove(
         .admin_roles
         .entry(guild_id)
         .or_default()
-        .retain(|r| !role_ids.contains(&r.0));
+        .retain(|r| !role_ids.contains(&(r.0 as i64)));
 
     let mut description = "Removed Admin Roles:\n".to_string();
     for role in role_ids {

--- a/rowifi/src/commands/settings/admin.rs
+++ b/rowifi/src/commands/settings/admin.rs
@@ -31,20 +31,14 @@ pub async fn admin(ctx: CommandContext, args: AdminArguments) -> CommandResult {
         return Ok(());
     }
 
-    if let Some(option) = args.option {
-        match option {
-            FunctionOption::Add => {
-                admin_add(ctx, guild, args.discord_roles.unwrap_or_default()).await
-            }
-            FunctionOption::Remove => {
-                admin_remove(ctx, guild, args.discord_roles.unwrap_or_default()).await
-            }
-            FunctionOption::Set => {
-                admin_set(ctx, guild, args.discord_roles.unwrap_or_default()).await
-            }
+    let option = args.option.unwrap_or_default();
+    match option {
+        FunctionOption::Add => admin_add(ctx, guild, args.discord_roles.unwrap_or_default()).await,
+        FunctionOption::Remove => {
+            admin_remove(ctx, guild, args.discord_roles.unwrap_or_default()).await
         }
-    } else {
-        admin_view(ctx, guild).await
+        FunctionOption::Set => admin_set(ctx, guild, args.discord_roles.unwrap_or_default()).await,
+        FunctionOption::View => admin_view(ctx, guild).await,
     }
 }
 

--- a/rowifi/src/commands/settings/admin.rs
+++ b/rowifi/src/commands/settings/admin.rs
@@ -1,7 +1,9 @@
 use mongodb::bson::doc;
 use rowifi_framework::prelude::*;
-use rowifi_models::guild::{GuildType, RoGuild};
-use twilight_model::id::RoleId;
+use rowifi_models::{
+    discord::id::RoleId,
+    guild::{GuildType, RoGuild},
+};
 
 use super::FunctionOption;
 

--- a/rowifi/src/commands/settings/bypass.rs
+++ b/rowifi/src/commands/settings/bypass.rs
@@ -131,7 +131,7 @@ pub async fn bypass_remove(
     let mut role_ids = Vec::new();
     for r in discord_roles.split_ascii_whitespace() {
         if let Some(r) = parse_role(r) {
-            role_ids.push(r);
+            role_ids.push(r as i64);
         }
     }
 
@@ -143,7 +143,7 @@ pub async fn bypass_remove(
         .bypass_roles
         .entry(guild_id)
         .or_default()
-        .retain(|r| !role_ids.contains(&r.0));
+        .retain(|r| !role_ids.contains(&(r.0 as i64)));
 
     let mut description = "Removed Bypass Roles:\n".to_string();
     for role in role_ids {

--- a/rowifi/src/commands/settings/bypass.rs
+++ b/rowifi/src/commands/settings/bypass.rs
@@ -31,20 +31,14 @@ pub async fn bypass(ctx: CommandContext, args: BypassArguments) -> CommandResult
         return Ok(());
     }
 
-    if let Some(option) = args.option {
-        match option {
-            FunctionOption::Add => {
-                bypass_add(ctx, guild, args.discord_roles.unwrap_or_default()).await
-            }
-            FunctionOption::Remove => {
-                bypass_remove(ctx, guild, args.discord_roles.unwrap_or_default()).await
-            }
-            FunctionOption::Set => {
-                bypass_set(ctx, guild, args.discord_roles.unwrap_or_default()).await
-            }
+    let option = args.option.unwrap_or_default();
+    match option {
+        FunctionOption::Add => bypass_add(ctx, guild, args.discord_roles.unwrap_or_default()).await,
+        FunctionOption::Remove => {
+            bypass_remove(ctx, guild, args.discord_roles.unwrap_or_default()).await
         }
-    } else {
-        bypass_view(ctx, guild).await
+        FunctionOption::Set => bypass_set(ctx, guild, args.discord_roles.unwrap_or_default()).await,
+        FunctionOption::View => bypass_view(ctx, guild).await,
     }
 }
 

--- a/rowifi/src/commands/settings/bypass.rs
+++ b/rowifi/src/commands/settings/bypass.rs
@@ -1,7 +1,9 @@
 use mongodb::bson::doc;
 use rowifi_framework::prelude::*;
-use rowifi_models::guild::{GuildType, RoGuild};
-use twilight_model::id::RoleId;
+use rowifi_models::{
+    discord::id::RoleId,
+    guild::{GuildType, RoGuild},
+};
 
 use super::FunctionOption;
 

--- a/rowifi/src/commands/settings/functional.rs
+++ b/rowifi/src/commands/settings/functional.rs
@@ -105,6 +105,7 @@ pub async fn functional(ctx: CommandContext, args: FunctionalArguments) -> Comma
         .timeout(Duration::from_secs(60));
     tokio::pin!(stream);
 
+    ctx.bot.ignore_message_components.insert(message_id);
     while let Some(Ok(event)) = stream.next().await {
         if let Event::InteractionCreate(interaction) = &event {
             if let Interaction::MessageComponent(message_component) = &interaction.0 {
@@ -226,23 +227,7 @@ pub async fn functional(ctx: CommandContext, args: FunctionalArguments) -> Comma
             }
         }
     }
-
-    if let Some(interaction_token) = &ctx.interaction_token {
-        ctx.bot
-            .http
-            .update_interaction_original(interaction_token)
-            .unwrap()
-            .components(Some(Vec::new()))
-            .unwrap()
-            .await?;
-    } else {
-        ctx.bot
-            .http
-            .update_message(ctx.channel_id, message_id)
-            .components(Some(Vec::new()))
-            .unwrap()
-            .await?;
-    }
+    ctx.bot.ignore_message_components.remove(&message_id);
 
     Ok(())
 }

--- a/rowifi/src/commands/settings/functional.rs
+++ b/rowifi/src/commands/settings/functional.rs
@@ -1,7 +1,6 @@
 use mongodb::bson::doc;
 use rowifi_framework::prelude::*;
-use rowifi_models::guild::GuildType;
-use twilight_model::id::RoleId;
+use rowifi_models::{discord::id::RoleId, guild::GuildType};
 
 #[derive(FromArgs)]
 pub struct FunctionalArguments {

--- a/rowifi/src/commands/settings/log.rs
+++ b/rowifi/src/commands/settings/log.rs
@@ -1,7 +1,6 @@
 use mongodb::bson::doc;
 use rowifi_framework::prelude::*;
-use rowifi_models::guild::GuildType;
-use twilight_model::id::ChannelId;
+use rowifi_models::{discord::id::ChannelId, guild::GuildType};
 
 #[derive(FromArgs)]
 pub struct LogChannelArguments {

--- a/rowifi/src/commands/settings/log.rs
+++ b/rowifi/src/commands/settings/log.rs
@@ -39,7 +39,7 @@ pub async fn log_channel(ctx: CommandContext, args: LogChannelArguments) -> Comm
         }
 
         let filter = doc! {"_id": guild.id};
-        let update = doc! {"$set": {"Settings.LogChannel": channel_id.0}};
+        let update = doc! {"$set": {"Settings.LogChannel": channel_id.0 as i64}};
         ctx.bot.database.modify_guild(filter, update).await?;
 
         ctx.bot.log_channels.insert(guild_id, channel_id);

--- a/rowifi/src/commands/settings/misc.rs
+++ b/rowifi/src/commands/settings/misc.rs
@@ -64,12 +64,12 @@ pub async fn toggle_commands(ctx: CommandContext, args: ToggleCommandsArguments)
     let option = args.option;
     let (update, desc, add) = match option {
         ToggleOption::Enable => (
-            doc! {"$pull": {"DisabledChannels": ctx.channel_id.0}},
+            doc! {"$pull": {"DisabledChannels": ctx.channel_id.0 as i64}},
             "Commands have been successfully enabled in this channel",
             false,
         ),
         ToggleOption::Disable => (
-            doc! {"$push": {"DisabledChannels": ctx.channel_id.0}},
+            doc! {"$push": {"DisabledChannels": ctx.channel_id.0 as i64}},
             "Commands have been successfully disabled in this channel",
             true,
         ),

--- a/rowifi/src/commands/settings/mod.rs
+++ b/rowifi/src/commands/settings/mod.rs
@@ -212,6 +212,13 @@ pub enum FunctionOption {
     Add,
     Remove,
     Set,
+    View,
+}
+
+impl Default for FunctionOption {
+    fn default() -> Self {
+        Self::View
+    }
 }
 
 impl FromArg for FunctionOption {
@@ -222,6 +229,7 @@ impl FromArg for FunctionOption {
             "add" => Ok(Self::Add),
             "remove" => Ok(Self::Remove),
             "set" => Ok(Self::Set),
+            "view" => Ok(Self::View),
             _ => Err(ParseError("one of `add` `remove` `set`")),
         }
     }

--- a/rowifi/src/commands/settings/nickname_bypass.rs
+++ b/rowifi/src/commands/settings/nickname_bypass.rs
@@ -33,20 +33,18 @@ pub async fn nickname_bypass(ctx: CommandContext, args: NicknameBypassArguments)
         return Ok(());
     }
 
-    if let Some(option) = args.option {
-        match option {
-            FunctionOption::Add => {
-                nickname_bypass_add(ctx, guild, args.discord_roles.unwrap_or_default()).await
-            }
-            FunctionOption::Remove => {
-                nickname_bypass_remove(ctx, guild, args.discord_roles.unwrap_or_default()).await
-            }
-            FunctionOption::Set => {
-                nickname_bypass_set(ctx, guild, args.discord_roles.unwrap_or_default()).await
-            }
+    let option = args.option.unwrap_or_default();
+    match option {
+        FunctionOption::Add => {
+            nickname_bypass_add(ctx, guild, args.discord_roles.unwrap_or_default()).await
         }
-    } else {
-        nickname_bypass_view(ctx, guild).await
+        FunctionOption::Remove => {
+            nickname_bypass_remove(ctx, guild, args.discord_roles.unwrap_or_default()).await
+        }
+        FunctionOption::Set => {
+            nickname_bypass_set(ctx, guild, args.discord_roles.unwrap_or_default()).await
+        }
+        FunctionOption::View => nickname_bypass_view(ctx, guild).await,
     }
 }
 

--- a/rowifi/src/commands/settings/nickname_bypass.rs
+++ b/rowifi/src/commands/settings/nickname_bypass.rs
@@ -134,7 +134,7 @@ pub async fn nickname_bypass_remove(
     let mut role_ids = Vec::new();
     for r in discord_roles.split_ascii_whitespace() {
         if let Some(r) = parse_role(r) {
-            role_ids.push(r);
+            role_ids.push(r as i64);
         }
     }
 
@@ -146,7 +146,7 @@ pub async fn nickname_bypass_remove(
         .nickname_bypass_roles
         .entry(guild_id)
         .or_default()
-        .retain(|r| !role_ids.contains(&r.0));
+        .retain(|r| !role_ids.contains(&(r.0 as i64)));
 
     let mut description = "Removed Nickname Bypass Roles:\n".to_string();
     for role in role_ids {

--- a/rowifi/src/commands/settings/nickname_bypass.rs
+++ b/rowifi/src/commands/settings/nickname_bypass.rs
@@ -1,7 +1,9 @@
 use mongodb::bson::doc;
 use rowifi_framework::prelude::*;
-use rowifi_models::guild::{GuildType, RoGuild};
-use twilight_model::id::RoleId;
+use rowifi_models::{
+    discord::id::RoleId,
+    guild::{GuildType, RoGuild},
+};
 
 use super::FunctionOption;
 

--- a/rowifi/src/commands/settings/trainer.rs
+++ b/rowifi/src/commands/settings/trainer.rs
@@ -130,7 +130,7 @@ pub async fn trainer_remove(
     let mut role_ids = Vec::new();
     for r in discord_roles.split_ascii_whitespace() {
         if let Some(r) = parse_role(r) {
-            role_ids.push(r);
+            role_ids.push(r as i64);
         }
     }
 
@@ -142,7 +142,7 @@ pub async fn trainer_remove(
         .trainer_roles
         .entry(guild_id)
         .or_default()
-        .retain(|r| !role_ids.contains(&r.0));
+        .retain(|r| !role_ids.contains(&(r.0 as i64)));
 
     let mut description = "Removed Trainer Roles:\n".to_string();
     for role in role_ids {

--- a/rowifi/src/commands/settings/trainer.rs
+++ b/rowifi/src/commands/settings/trainer.rs
@@ -31,20 +31,18 @@ pub async fn trainer(ctx: CommandContext, args: TrainerArguments) -> CommandResu
         return Ok(());
     }
 
-    if let Some(option) = args.option {
-        match option {
-            FunctionOption::Add => {
-                trainer_add(ctx, guild, args.discord_roles.unwrap_or_default()).await
-            }
-            FunctionOption::Remove => {
-                trainer_remove(ctx, guild, args.discord_roles.unwrap_or_default()).await
-            }
-            FunctionOption::Set => {
-                trainer_set(ctx, guild, args.discord_roles.unwrap_or_default()).await
-            }
+    let option = args.option.unwrap_or_default();
+    match option {
+        FunctionOption::Add => {
+            trainer_add(ctx, guild, args.discord_roles.unwrap_or_default()).await
         }
-    } else {
-        trainer_view(ctx, guild).await
+        FunctionOption::Remove => {
+            trainer_remove(ctx, guild, args.discord_roles.unwrap_or_default()).await
+        }
+        FunctionOption::Set => {
+            trainer_set(ctx, guild, args.discord_roles.unwrap_or_default()).await
+        }
+        FunctionOption::View => trainer_view(ctx, guild).await,
     }
 }
 

--- a/rowifi/src/commands/settings/trainer.rs
+++ b/rowifi/src/commands/settings/trainer.rs
@@ -1,7 +1,9 @@
 use mongodb::bson::doc;
 use rowifi_framework::prelude::*;
-use rowifi_models::guild::{GuildType, RoGuild};
-use twilight_model::id::RoleId;
+use rowifi_models::{
+    discord::id::RoleId,
+    guild::{GuildType, RoGuild},
+};
 
 use super::FunctionOption;
 

--- a/rowifi/src/commands/settings/verify.rs
+++ b/rowifi/src/commands/settings/verify.rs
@@ -1,6 +1,6 @@
 use mongodb::bson::doc;
 use rowifi_framework::prelude::*;
-use twilight_model::id::RoleId;
+use rowifi_models::discord::id::RoleId;
 
 #[derive(FromArgs)]
 pub struct VerificationArguments {

--- a/rowifi/src/commands/settings/verify.rs
+++ b/rowifi/src/commands/settings/verify.rs
@@ -17,7 +17,7 @@ pub async fn settings_verification(
 
     let verification_role = args.role.0;
     let filter = doc! {"_id": guild.id};
-    let update = doc! {"$set": {"VerificationRole": verification_role}};
+    let update = doc! {"$set": {"VerificationRole": verification_role as i64}};
     ctx.bot.database.modify_guild(filter, update).await?;
 
     let embed = EmbedBuilder::new()
@@ -57,7 +57,7 @@ pub async fn settings_verified(ctx: CommandContext, args: VerifiedArguments) -> 
 
     let verified_role = args.role.0;
     let filter = doc! {"_id": guild.id};
-    let update = doc! {"$set": {"VerifiedRole": verified_role}};
+    let update = doc! {"$set": {"VerifiedRole": verified_role as i64}};
     ctx.bot.database.modify_guild(filter, update).await?;
 
     let embed = EmbedBuilder::new()

--- a/rowifi/src/commands/settings/verify.rs
+++ b/rowifi/src/commands/settings/verify.rs
@@ -17,7 +17,7 @@ pub async fn settings_verification(
 
     let verification_role = args.role.0;
     let filter = doc! {"_id": guild.id};
-    let update = doc! {"$set": {"VerificationRole": verification_role as i64}};
+    let update = doc! {"$set": {"VerificationRole": verification_role as i64, "VerificationRoles": [verification_role as i64]}};
     ctx.bot.database.modify_guild(filter, update).await?;
 
     let embed = EmbedBuilder::new()
@@ -57,7 +57,7 @@ pub async fn settings_verified(ctx: CommandContext, args: VerifiedArguments) -> 
 
     let verified_role = args.role.0;
     let filter = doc! {"_id": guild.id};
-    let update = doc! {"$set": {"VerifiedRole": verified_role as i64}};
+    let update = doc! {"$set": {"VerifiedRole": verified_role as i64, "VerifiedRoles": [verified_role as i64]}};
     ctx.bot.database.modify_guild(filter, update).await?;
 
     let embed = EmbedBuilder::new()

--- a/rowifi/src/commands/user/info.rs
+++ b/rowifi/src/commands/user/info.rs
@@ -23,12 +23,7 @@ pub async fn userinfo(ctx: CommandContext, args: UserInfoArguments) -> CommandRe
                 .description("User was not verified. Please ask him/her to verify themselves")
                 .build()
                 .unwrap();
-            ctx.bot
-                .http
-                .create_message(ctx.channel_id)
-                .embeds(vec![embed])
-                .unwrap()
-                .await?;
+            ctx.respond().embeds(vec![embed]).await?;
             return Ok(());
         }
     };

--- a/rowifi/src/commands/user/info.rs
+++ b/rowifi/src/commands/user/info.rs
@@ -1,7 +1,8 @@
 use rowifi_framework::prelude::*;
-use rowifi_models::roblox::id::UserId as RobloxUserId;
-use twilight_embed_builder::{EmbedFieldBuilder, ImageSource};
-use twilight_model::id::{GuildId, UserId};
+use rowifi_models::{
+    discord::id::{GuildId, UserId},
+    roblox::id::UserId as RobloxUserId,
+};
 
 #[derive(FromArgs)]
 pub struct UserInfoArguments {

--- a/rowifi/src/commands/user/info.rs
+++ b/rowifi/src/commands/user/info.rs
@@ -32,7 +32,7 @@ pub async fn userinfo(ctx: CommandContext, args: UserInfoArguments) -> CommandRe
     let roblox_user = ctx
         .bot
         .roblox
-        .get_user(RobloxUserId(user.roblox_id as u64))
+        .get_user(RobloxUserId(user.roblox_id as u64), false)
         .await?;
 
     let embed = EmbedBuilder::new()

--- a/rowifi/src/commands/user/mod.rs
+++ b/rowifi/src/commands/user/mod.rs
@@ -3,10 +3,11 @@ mod test;
 mod update;
 mod verify;
 
-pub use info::{botinfo, support, userinfo};
 use rowifi_framework::prelude::*;
+use rowifi_models::discord::id::MessageId;
+
+pub use info::{botinfo, support, userinfo};
 pub use test::test;
-use twilight_model::id::MessageId;
 pub use update::update;
 pub use verify::{verify, verify_config};
 

--- a/rowifi/src/commands/user/mod.rs
+++ b/rowifi/src/commands/user/mod.rs
@@ -69,6 +69,7 @@ pub async fn handle_update_button(
         .timeout(Duration::from_secs(60));
     tokio::pin!(stream);
 
+    ctx.bot.ignore_message_components.insert(message_id);
     while let Some(Ok(event)) = stream.next().await {
         if let Event::InteractionCreate(interaction) = &event {
             if let Interaction::MessageComponent(message_component) = &interaction.0 {
@@ -99,7 +100,7 @@ pub async fn handle_update_button(
                         .unwrap()
                         .embeds(vec![embed])
                         .await?;
-                    return Ok(());
+                    break;
                 }
                 let _ = ctx
                     .bot
@@ -121,23 +122,7 @@ pub async fn handle_update_button(
             }
         }
     }
-
-    if let Some(interaction_token) = &ctx.interaction_token {
-        ctx.bot
-            .http
-            .update_interaction_original(interaction_token)
-            .unwrap()
-            .components(None)
-            .unwrap()
-            .await?;
-    } else {
-        ctx.bot
-            .http
-            .update_message(ctx.channel_id, message_id)
-            .components(None)
-            .unwrap()
-            .await?;
-    }
+    ctx.bot.ignore_message_components.remove(&message_id);
 
     Ok(())
 }

--- a/rowifi/src/commands/user/mod.rs
+++ b/rowifi/src/commands/user/mod.rs
@@ -94,7 +94,7 @@ pub async fn handle_update_button(
                         )
                         .await?;
 
-                    let embed = update_func(ctx, UpdateArguments { user_id: None }).await?;
+                    let embed = update_func(ctx, UpdateArguments { user_id: None }, false).await?;
                     ctx.bot
                         .http
                         .create_followup_message(&message_component.token)

--- a/rowifi/src/commands/user/update.rs
+++ b/rowifi/src/commands/user/update.rs
@@ -126,7 +126,8 @@ pub async fn update_func(ctx: &CommandContext, args: UpdateArguments) -> Result<
                     .build()
                     .unwrap();
                 if let Ok(channel) = ctx.bot.http.create_private_channel(user_id).await {
-                    ctx.bot
+                    let _ = ctx
+                        .bot
                         .http
                         .create_message(channel.id)
                         .content(format!(
@@ -134,7 +135,7 @@ pub async fn update_func(ctx: &CommandContext, args: UpdateArguments) -> Result<
                             server.name, b
                         ))
                         .unwrap()
-                        .await?;
+                        .await;
                 }
                 return Ok(embed);
             }

--- a/rowifi/src/commands/user/update.rs
+++ b/rowifi/src/commands/user/update.rs
@@ -1,11 +1,10 @@
 use hyper::StatusCode;
 use rowifi_framework::prelude::*;
-use twilight_embed_builder::EmbedFooterBuilder;
-use twilight_http::error::ErrorType as DiscordErrorType;
-use twilight_model::{
+use rowifi_models::discord::{
     channel::embed::Embed,
     id::{RoleId, UserId},
 };
+use twilight_http::error::ErrorType as DiscordErrorType;
 
 #[derive(Debug, FromArgs)]
 pub struct UpdateArguments {

--- a/rowifi/src/commands/user/verify/manage.rs
+++ b/rowifi/src/commands/user/verify/manage.rs
@@ -42,12 +42,7 @@ pub async fn verify_switch(ctx: CommandContext, args: VerifyArguments) -> Comman
                 .description("Invalid Roblox Username. Please try again.")
                 .build()
                 .unwrap();
-            ctx.bot
-                .http
-                .create_message(ctx.channel_id)
-                .embeds(vec![e])
-                .unwrap()
-                .await?;
+            ctx.respond().embeds(vec![e]).await?;
             return Ok(());
         }
     };
@@ -61,12 +56,7 @@ pub async fn verify_switch(ctx: CommandContext, args: VerifyArguments) -> Comman
             .description("The provided username is not linked to your discord account. Please link it using `verify add`")
             .build()
             .unwrap();
-        ctx.bot
-            .http
-            .create_message(ctx.channel_id)
-            .embeds(vec![e])
-            .unwrap()
-            .await?;
+        ctx.respond().embeds(vec![e]).await?;
         return Ok(());
     }
 
@@ -83,12 +73,9 @@ pub async fn verify_switch(ctx: CommandContext, args: VerifyArguments) -> Comman
         .title("Account Switching Successful")
         .build()
         .unwrap();
-    let message = ctx
-        .bot
-        .http
-        .create_message(ctx.channel_id)
+    let message_id = ctx
+        .respond()
         .embeds(vec![embed])
-        .unwrap()
         .components(vec![Component::ActionRow(ActionRow {
             components: vec![Component::Button(Button {
                 custom_id: Some("handle-update".into()),
@@ -99,10 +86,9 @@ pub async fn verify_switch(ctx: CommandContext, args: VerifyArguments) -> Comman
                 url: None,
             })],
         })])
-        .unwrap()
         .await?;
 
-    handle_update_button(&ctx, message.id, Vec::new()).await?;
+    handle_update_button(&ctx, message_id.unwrap(), Vec::new()).await?;
 
     Ok(())
 }
@@ -143,12 +129,7 @@ pub async fn verify_default(ctx: CommandContext, args: VerifyArguments) -> Comma
                 .description("Invalid Roblox Username. Please try again.")
                 .build()
                 .unwrap();
-            ctx.bot
-                .http
-                .create_message(ctx.channel_id)
-                .embeds(vec![e])
-                .unwrap()
-                .await?;
+            ctx.respond().embeds(vec![e]).await?;
             return Ok(());
         }
     };
@@ -164,12 +145,7 @@ pub async fn verify_default(ctx: CommandContext, args: VerifyArguments) -> Comma
                 .description("The provided username is not linked to your discord account or is already your default account")
                 .build()
                 .unwrap();
-            ctx.bot
-                .http
-                .create_message(ctx.channel_id)
-                .embeds(vec![e])
-                .unwrap()
-                .await?;
+            ctx.respond().embeds(vec![e]).await?;
             return Ok(());
         }
     };
@@ -184,12 +160,9 @@ pub async fn verify_default(ctx: CommandContext, args: VerifyArguments) -> Comma
         .title("Default Account Set Successfully")
         .build()
         .unwrap();
-    let message = ctx
-        .bot
-        .http
-        .create_message(ctx.channel_id)
+    let message_id = ctx
+        .respond()
         .embeds(vec![embed])
-        .unwrap()
         .components(vec![Component::ActionRow(ActionRow {
             components: vec![Component::Button(Button {
                 custom_id: Some("handle-update".into()),
@@ -200,10 +173,9 @@ pub async fn verify_default(ctx: CommandContext, args: VerifyArguments) -> Comma
                 url: None,
             })],
         })])
-        .unwrap()
         .await?;
 
-    handle_update_button(&ctx, message.id, Vec::new()).await?;
+    handle_update_button(&ctx, message_id.unwrap(), Vec::new()).await?;
 
     Ok(())
 }
@@ -244,12 +216,7 @@ pub async fn verify_delete(ctx: CommandContext, args: VerifyArguments) -> Comman
                 .description("Invalid Roblox Username. Please try again.")
                 .build()
                 .unwrap();
-            ctx.bot
-                .http
-                .create_message(ctx.channel_id)
-                .embeds(vec![e])
-                .unwrap()
-                .await?;
+            ctx.respond().embeds(vec![e]).await?;
             return Ok(());
         }
     };
@@ -265,12 +232,7 @@ pub async fn verify_delete(ctx: CommandContext, args: VerifyArguments) -> Comman
                 .description("The provided username is not linked to your discord account or is your default account")
                 .build()
                 .unwrap();
-            ctx.bot
-                .http
-                .create_message(ctx.channel_id)
-                .embeds(vec![e])
-                .unwrap()
-                .await?;
+            ctx.respond().embeds(vec![e]).await?;
             return Ok(());
         }
     };
@@ -286,12 +248,9 @@ pub async fn verify_delete(ctx: CommandContext, args: VerifyArguments) -> Comman
         .title("Account Unlinking Successful")
         .build()
         .unwrap();
-    let message = ctx
-        .bot
-        .http
-        .create_message(ctx.channel_id)
+    let message_id = ctx
+        .respond()
         .embeds(vec![embed])
-        .unwrap()
         .components(vec![Component::ActionRow(ActionRow {
             components: vec![Component::Button(Button {
                 custom_id: Some("handle-update".into()),
@@ -302,10 +261,9 @@ pub async fn verify_delete(ctx: CommandContext, args: VerifyArguments) -> Comman
                 url: None,
             })],
         })])
-        .unwrap()
         .await?;
 
-    handle_update_button(&ctx, message.id, Vec::new()).await?;
+    handle_update_button(&ctx, message_id.unwrap(), Vec::new()).await?;
 
     Ok(())
 }

--- a/rowifi/src/commands/user/verify/mod.rs
+++ b/rowifi/src/commands/user/verify/mod.rs
@@ -248,7 +248,7 @@ pub async fn verify_view(ctx: CommandContext) -> CommandResult {
     let main_user = ctx
         .bot
         .roblox
-        .get_user(RobloxUserId(user.roblox_id as u64))
+        .get_user(RobloxUserId(user.roblox_id as u64), false)
         .await?;
     acc_string.push_str(&main_user.name);
     acc_string.push_str(" - `Default`");
@@ -261,7 +261,11 @@ pub async fn verify_view(ctx: CommandContext) -> CommandResult {
     }
     acc_string.push('\n');
     for alt in &user.alts {
-        let user = ctx.bot.roblox.get_user(RobloxUserId(*alt as u64)).await?;
+        let user = ctx
+            .bot
+            .roblox
+            .get_user(RobloxUserId(*alt as u64), false)
+            .await?;
         acc_string.push_str(&user.name);
         if let Some(linked_user) = &linked_user {
             if linked_user.roblox_id == *alt {

--- a/rowifi/src/commands/user/verify/mod.rs
+++ b/rowifi/src/commands/user/verify/mod.rs
@@ -138,12 +138,7 @@ pub async fn verify_common(
                 .description("Invalid Roblox Username. Please try again.")
                 .build()
                 .unwrap();
-            ctx.bot
-                .http
-                .create_message(ctx.channel_id)
-                .embeds(vec![e])
-                .unwrap()
-                .await?;
+            ctx.respond().embeds(vec![e]).await?;
             return Ok(());
         }
     };
@@ -176,12 +171,9 @@ pub async fn verify_common(
         url: Some(game_url.into()),
         disabled: false,
     });
-    let message = ctx
-        .bot
-        .http
-        .create_message(ctx.channel_id)
+    let message_id = ctx
+        .respond()
         .embeds(vec![e])
-        .unwrap()
         .components(vec![Component::ActionRow(ActionRow {
             components: vec![
                 game_url_button.clone(),
@@ -195,7 +187,6 @@ pub async fn verify_common(
                 }),
             ],
         })])
-        .unwrap()
         .await?;
     let q_user = QueueUser {
         roblox_id,
@@ -206,7 +197,7 @@ pub async fn verify_common(
 
     handle_update_button(
         &ctx,
-        message.id,
+        message_id.unwrap(),
         vec![Component::ActionRow(ActionRow {
             components: vec![game_url_button],
         })],
@@ -227,12 +218,7 @@ pub async fn verify_view(ctx: CommandContext) -> CommandResult {
                 .color(Color::Red as u32)
                 .build()
                 .unwrap();
-            ctx.bot
-                .http
-                .create_message(ctx.channel_id)
-                .embeds(vec![embed])
-                .unwrap()
-                .await?;
+            ctx.respond().embeds(vec![embed]).await?;
             return Ok(());
         }
     };
@@ -276,12 +262,7 @@ pub async fn verify_view(ctx: CommandContext) -> CommandResult {
     }
 
     let embed = embed.description(acc_string).build().unwrap();
-    ctx.bot
-        .http
-        .create_message(ctx.channel_id)
-        .embeds(vec![embed])
-        .unwrap()
-        .await?;
+    ctx.respond().embeds(vec![embed]).await?;
 
     Ok(())
 }

--- a/rowifi/src/commands/user/verify/mod.rs
+++ b/rowifi/src/commands/user/verify/mod.rs
@@ -46,6 +46,12 @@ pub fn verify_config(cmds: &mut Vec<Command>) {
         .description("Command to view all linked accounts")
         .handler(verify_view);
 
+    let verify_setup_cmd = Command::builder()
+        .level(RoLevel::Normal)
+        .names(&["setup"])
+        .description("Command to link a roblox account to your discord account")
+        .handler(verify);
+
     let verify_cmd = Command::builder()
         .level(RoLevel::Normal)
         .names(&["verify"])
@@ -56,6 +62,7 @@ pub fn verify_config(cmds: &mut Vec<Command>) {
         .sub_command(verify_default_cmd)
         .sub_command(verify_delete_cmd)
         .sub_command(verify_view_cmd)
+        .sub_command(verify_setup_cmd)
         .handler(verify);
 
     cmds.push(verify_cmd);

--- a/rowifi/src/commands/user/verify/mod.rs
+++ b/rowifi/src/commands/user/verify/mod.rs
@@ -1,11 +1,14 @@
 mod manage;
 
 use rowifi_framework::prelude::*;
-use rowifi_models::{roblox::id::UserId as RobloxUserId, user::QueueUser};
-use twilight_model::application::component::{
-    action_row::ActionRow,
-    button::{Button, ButtonStyle},
-    Component,
+use rowifi_models::{
+    discord::application::component::{
+        action_row::ActionRow,
+        button::{Button, ButtonStyle},
+        Component,
+    },
+    roblox::id::UserId as RobloxUserId,
+    user::QueueUser,
 };
 
 use crate::commands::handle_update_button;

--- a/rowifi/src/main.rs
+++ b/rowifi/src/main.rs
@@ -30,7 +30,10 @@ use roblox::Client as RobloxClient;
 use rowifi_cache::Cache;
 use rowifi_database::Database;
 use rowifi_framework::{context::BotContext, Framework};
-use rowifi_models::stats::BotStats;
+use rowifi_models::{
+    discord::{gateway::Intents, guild::Permissions},
+    stats::BotStats,
+};
 use rowifi_redis::{RedisManager, RedisPool};
 use services::EventHandler;
 use std::{
@@ -50,7 +53,6 @@ use twilight_gateway::{
     Event,
 };
 use twilight_http::Client as HttpClient;
-use twilight_model::{gateway::Intents, guild::Permissions};
 use twilight_standby::Standby;
 
 pub struct RoWifi {

--- a/rowifi/src/services/activity.rs
+++ b/rowifi/src/services/activity.rs
@@ -1,10 +1,10 @@
 use rowifi_framework::context::BotContext;
-use std::error::Error;
-use tokio::time::{interval, Duration};
-use twilight_model::gateway::{
+use rowifi_models::discord::gateway::{
     payload::UpdatePresence,
     presence::{Activity, ActivityType, Status},
 };
+use std::error::Error;
+use tokio::time::{interval, Duration};
 
 pub async fn activity(ctx: BotContext) {
     let mut interval = interval(Duration::from_secs(30 * 60));

--- a/rowifi/src/services/auto_detection.rs
+++ b/rowifi/src/services/auto_detection.rs
@@ -1,17 +1,17 @@
 use itertools::Itertools;
 use rowifi_cache::CachedGuild;
-use rowifi_framework::{
-    context::BotContext,
-    prelude::{EmbedExtensions, RoError},
+use rowifi_framework::{context::BotContext, prelude::*};
+use rowifi_models::{
+    discord::{
+        gateway::{event::Event, payload::RequestGuildMembers},
+        id::{GuildId, RoleId, UserId},
+    },
+    guild::RoGuild,
+    roblox::id::UserId as RobloxUserId,
+    user::RoGuildUser,
 };
-use rowifi_models::{guild::RoGuild, roblox::id::UserId as RobloxUserId, user::RoGuildUser};
 use std::{collections::HashSet, env, error::Error, sync::atomic::Ordering};
 use tokio::time::{interval, sleep, timeout, Duration};
-use twilight_embed_builder::EmbedBuilder;
-use twilight_model::{
-    gateway::{event::Event, payload::RequestGuildMembers},
-    id::{GuildId, RoleId, UserId},
-};
 
 pub async fn auto_detection(ctx: BotContext) {
     tracing::info!("Auto Detection starting");

--- a/rowifi/src/services/auto_detection.rs
+++ b/rowifi/src/services/auto_detection.rs
@@ -30,7 +30,12 @@ pub async fn auto_detection(ctx: BotContext) {
 }
 
 async fn execute(ctx: &BotContext, chunk_size: usize) -> Result<(), Box<dyn Error>> {
-    let servers = ctx.cache.guilds().into_iter().map(|s| s as i64).collect::<Vec<_>>();
+    let servers = ctx
+        .cache
+        .guilds()
+        .into_iter()
+        .map(|s| s as i64)
+        .collect::<Vec<_>>();
     let mut guilds = ctx.database.get_guilds(&servers, true).await?;
     guilds.sort_by_key(|g| g.id);
     for guild in guilds {

--- a/rowifi/src/services/auto_detection.rs
+++ b/rowifi/src/services/auto_detection.rs
@@ -30,7 +30,7 @@ pub async fn auto_detection(ctx: BotContext) {
 }
 
 async fn execute(ctx: &BotContext, chunk_size: usize) -> Result<(), Box<dyn Error>> {
-    let servers = ctx.cache.guilds();
+    let servers = ctx.cache.guilds().into_iter().map(|s| s as i64).collect::<Vec<_>>();
     let mut guilds = ctx.database.get_guilds(&servers, true).await?;
     guilds.sort_by_key(|g| g.id);
     for guild in guilds {
@@ -44,7 +44,7 @@ async fn execute(ctx: &BotContext, chunk_size: usize) -> Result<(), Box<dyn Erro
             .cache
             .members(guild_id)
             .into_iter()
-            .map(|m| m.0)
+            .map(|m| m.0 as i64)
             .collect::<Vec<_>>();
         if (members.len() as i64) < server.member_count.load(Ordering::SeqCst) / 2 {
             let req = RequestGuildMembers::builder(server.id).query("", None);
@@ -66,7 +66,7 @@ async fn execute(ctx: &BotContext, chunk_size: usize) -> Result<(), Box<dyn Erro
                 .cache
                 .members(guild_id)
                 .into_iter()
-                .map(|m| m.0)
+                .map(|m| m.0 as i64)
                 .collect::<Vec<_>>();
         }
         let users = ctx.database.get_linked_users(&members, guild_id.0).await?;

--- a/rowifi/src/services/auto_detection.rs
+++ b/rowifi/src/services/auto_detection.rs
@@ -114,7 +114,7 @@ async fn execute_chunk(
             tracing::trace!(id = user.discord_id, "Auto Detection for member");
             let name = member.user.name.clone();
             if let Ok((added_roles, removed_roles, disc_nick)) = ctx
-                .update_user(member, user, server, guild, guild_roles)
+                .update_user(member, user, server, guild, guild_roles, false)
                 .await
             {
                 if !added_roles.is_empty() || !removed_roles.is_empty() {

--- a/rowifi/src/services/event_handler.rs
+++ b/rowifi/src/services/event_handler.rs
@@ -190,7 +190,7 @@ impl Service<(u64, Event)> for EventHandler {
 
                     let guild_roles = eh.bot.cache.roles(m.guild_id);
                     let (added_roles, removed_roles, disc_nick) = match eh.bot
-                        .update_user(member, &user, &server, &guild, &guild_roles)
+                        .update_user(member, &user, &server, &guild, &guild_roles, false)
                         .await
                     {
                         Ok(a) => a,

--- a/rowifi/src/services/event_handler.rs
+++ b/rowifi/src/services/event_handler.rs
@@ -1,11 +1,15 @@
 use super::{activity, auto_detection};
 use dashmap::DashSet;
 use futures_util::future::{Future, FutureExt};
-use rowifi_framework::{
-    context::BotContext,
-    prelude::{CommandError, EmbedExtensions, RoError},
+use rowifi_framework::{context::BotContext, prelude::*};
+use rowifi_models::{
+    discord::{
+        channel::GuildChannel,
+        guild::Permissions,
+        id::{ChannelId, GuildId, RoleId},
+    },
+    guild::GuildType,
 };
-use rowifi_models::guild::GuildType;
 use std::{
     pin::Pin,
     sync::{
@@ -15,13 +19,7 @@ use std::{
     task::{Context, Poll},
 };
 use tower::Service;
-use twilight_embed_builder::EmbedBuilder;
 use twilight_gateway::Event;
-use twilight_model::{
-    channel::GuildChannel,
-    guild::Permissions,
-    id::{ChannelId, GuildId, RoleId},
-};
 
 pub struct EventHandlerRef {
     unavailable: DashSet<GuildId>,

--- a/rowifi/src/services/event_handler.rs
+++ b/rowifi/src/services/event_handler.rs
@@ -136,8 +136,8 @@ impl Service<(u64, Event)> for EventHandler {
                     let guild_ids = ready
                         .guilds
                         .iter()
-                        .map(|k| k.id.0)
-                        .collect::<Vec<u64>>();
+                        .map(|k| k.id.0 as i64)
+                        .collect::<Vec<_>>();
                     let guilds = eh.bot.database.get_guilds(&guild_ids, false).await?;
                     for guild in guilds {
                         let guild_id = GuildId(guild.id as u64);


### PR DESCRIPTION
Tracking PR for version 3.1.1

It will be updated as stuff is added

Changelog:
- [x] Don't delete components on timeout
- [x] Add all commands as slash commands
- [x] Add confirmation prompt to reset
- [x] Add `disabled` field to event types
- [x] Add commands `event type disable` and `event type enable`
- [x] Add command `event reset` to delete all logged events and created event types
- [x] Add command `event summary` to summarize the logged history of all event types

Internal changes:
- [ ] Update `twilight` to v0.6 (Waiting for the message components branch to be rebased)
- [x] Clean up imports 