### PR TITLE
chore: modify all crates to use the 2021 edition

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,9 +1,0 @@
-[target.x86_64-unknown-linux-gnu]
-linker = "/usr/bin/clang-13"
-rustflags = ["-Clink-arg=-fuse-ld=lld"]
-
-[target.x86_64-apple-darwin]
-rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/zld"]
-
-[target.x86_64-pc-windows-msvc]
-linker = "rust-lld.exe"

--- a/cache/Cargo.toml
+++ b/cache/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rowifi-cache"
 version = "3.1.1"
 authors = ["Gautam.A <gautam.abhyankar@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rowifi-database"
 version = "3.1.1"
 authors = ["Gautam.A <gautam.abhyankar@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/framework/Cargo.toml
+++ b/framework/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rowifi-framework"
 version = "3.2.0"
 authors = ["AsianIntel <gautam.abhyankar@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/framework/src/handler.rs
+++ b/framework/src/handler.rs
@@ -105,6 +105,7 @@ where
 
                 let ctx = req.0;
                 let fut = async move {
+                    let _ = &ctx;
                     ctx.bot
                         .http
                         .create_message(ctx.channel_id)

--- a/models/Cargo.toml
+++ b/models/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rowifi-models"
 version = "3.1.2"
 authors = ["Gautam.A <gautam.abhyankar@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rowifi-redis"
 version = "3.0.0"
 authors = ["AsianIntel <gautam.abhyankar@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/roblox/Cargo.toml
+++ b/roblox/Cargo.toml
@@ -2,7 +2,7 @@
 name = "roblox"
 version = "0.3.1"
 authors = ["AsianIntel <gautam.abhyankar@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/rowifi/Cargo.toml
+++ b/rowifi/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rowifi"
 version = "3.1.2"
 authors = ["Gautam.A <gautam.abhyankar@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
All crates now have Rust edition to `2021`. The PR also removes the extra cargo config used in local development since it now causes issues with RA in WSL2 and does not have dramatic improvements.