### PR TITLE
Optimize mass update commands to avoid being ratelimited

### DIFF
--- a/rowifi/src/services/mod.rs
+++ b/rowifi/src/services/mod.rs
@@ -1,7 +1,7 @@
-mod activity;
-mod auto_detection;
-mod event_handler;
+pub mod activity;
+pub mod auto_detection;
+pub mod event_handler;
 
 pub use activity::activity;
-pub use auto_detection::*;
+pub use auto_detection::auto_detection;
 pub use event_handler::EventHandler;


### PR DESCRIPTION
The PR modifies the `update-all` and `update-role` commands to use the `execute_chunk` method used by Auto Detection. This has been done to not get ratelimited by the Roblox API.