### PR TITLE
Add Id types to interface with the database easily

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1311,6 +1311,7 @@ dependencies = [
  "postgres-protocol",
  "serde",
  "serde_json",
+ "uuid",
 ]
 
 [[package]]
@@ -1610,6 +1611,7 @@ dependencies = [
  "serde_repr",
  "tokio-postgres",
  "twilight-model",
+ "uuid",
 ]
 
 [[package]]
@@ -2350,6 +2352,15 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "uwl"

--- a/cache/src/event.rs
+++ b/cache/src/event.rs
@@ -204,8 +204,8 @@ impl UpdateCache for InteractionCreate {
 impl UpdateCache for MemberAdd {
     fn update(&self, c: &Cache) -> Result<(), CacheError> {
         let guild_id = GuildId(self.guild_id);
-        c.cache_member(self.guild_id, self.0.clone());
-        if let Some(guild) = c.guild(self.guild_id) {
+        c.cache_member(guild_id, self.0.clone());
+        if let Some(guild) = c.guild(guild_id) {
             guild.member_count.fetch_add(1, Ordering::SeqCst);
             c.0.stats.resource_counts.users.inc();
         }

--- a/cache/src/event.rs
+++ b/cache/src/event.rs
@@ -1,15 +1,19 @@
-use rowifi_models::{discord::{
-    application::interaction::Interaction,
-    channel::Channel,
-    gateway::{
-        event::Event,
-        payload::incoming::{
-            ChannelCreate, ChannelDelete, ChannelUpdate, GuildCreate, GuildDelete, GuildUpdate,
-            InteractionCreate, MemberAdd, MemberChunk, MemberRemove, MemberUpdate, MessageCreate,
-            Ready, RoleCreate, RoleDelete, RoleUpdate, UnavailableGuild, UserUpdate,
+use rowifi_models::{
+    discord::{
+        application::interaction::Interaction,
+        channel::Channel,
+        gateway::{
+            event::Event,
+            payload::incoming::{
+                ChannelCreate, ChannelDelete, ChannelUpdate, GuildCreate, GuildDelete, GuildUpdate,
+                InteractionCreate, MemberAdd, MemberChunk, MemberRemove, MemberUpdate,
+                MessageCreate, Ready, RoleCreate, RoleDelete, RoleUpdate, UnavailableGuild,
+                UserUpdate,
+            },
         },
     },
-}, id::{GuildId, RoleId, UserId, ChannelId}};
+    id::{ChannelId, GuildId, RoleId, UserId},
+};
 use std::{
     ops::Deref,
     sync::{atomic::Ordering, Arc},
@@ -223,7 +227,7 @@ impl UpdateCache for MemberChunk {
 impl UpdateCache for MemberRemove {
     fn update(&self, c: &Cache) -> Result<(), CacheError> {            
         let guild_id = GuildId(self.guild_id);
-        let user_id  = UserId(self.user.id);
+        let user_id = UserId(self.user.id);
         c.0.members.remove(&(guild_id, user_id));
         if let Some(mut members) = c.0.guild_members.get_mut(&guild_id) {
             if let Some(guild) = c.guild(guild_id) {

--- a/cache/src/lib.rs
+++ b/cache/src/lib.rs
@@ -20,7 +20,7 @@ use rowifi_models::{
         guild::{Guild, Member, Permissions, Role},
         user::{CurrentUser, User},
     },
-    id::{GuildId, RoleId, ChannelId, UserId},
+    id::{ChannelId, GuildId, RoleId, UserId},
     stats::BotStats,
 };
 use std::{
@@ -353,7 +353,8 @@ impl Cache {
                 .collect::<HashMap<RoleId, Arc<CachedRole>>>();
             let member = self.member(guild_id, UserId(user.id)).unwrap();
             let new_permissions =
-                match guild_wide_permissions(&guild, &server_roles, UserId(user.id), &member.roles) {
+                match guild_wide_permissions(&guild, &server_roles, UserId(user.id), &member.roles)
+                {
                     Ok(p) => p,
                     Err(why) => {
                         tracing::error!(guild = ?guild_id, reason = ?why);
@@ -468,7 +469,11 @@ impl Cache {
     }
 
     fn delete_guild_channel(&self, tc: &GuildChannel) -> Option<Arc<GuildChannel>> {
-        let channel = self.0.channels.remove(&ChannelId(tc.id())).map(|(_, c)| c)?;
+        let channel = self
+            .0
+            .channels
+            .remove(&ChannelId(tc.id()))
+            .map(|(_, c)| c)?;
         let guild_id = GuildId(tc.guild_id().unwrap());
         if let Some(mut channels) = self.0.guild_channels.get_mut(&guild_id) {
             channels.remove(&ChannelId(tc.id()));

--- a/cache/src/models/guild.rs
+++ b/cache/src/models/guild.rs
@@ -1,7 +1,7 @@
-use rowifi_models::{discord::{
-    datetime::Timestamp,
-    guild::Permissions,
-}, id::{GuildId, RoleId, ChannelId, UserId}};
+use rowifi_models::{
+    discord::{datetime::Timestamp, guild::Permissions},
+    id::{ChannelId, GuildId, RoleId, UserId},
+};
 use std::sync::{atomic::AtomicI64, Arc};
 
 #[derive(Debug, Clone)]

--- a/cache/src/models/guild.rs
+++ b/cache/src/models/guild.rs
@@ -1,8 +1,7 @@
 use rowifi_models::{discord::{
     datetime::Timestamp,
     guild::Permissions,
-    id::{ChannelId, UserId},
-}, id::{GuildId, RoleId}};
+}, id::{GuildId, RoleId, ChannelId, UserId}};
 use std::sync::{atomic::AtomicI64, Arc};
 
 #[derive(Debug, Clone)]

--- a/cache/src/models/guild.rs
+++ b/cache/src/models/guild.rs
@@ -1,8 +1,8 @@
 use rowifi_models::{discord::{
     datetime::Timestamp,
     guild::Permissions,
-    id::{ChannelId, RoleId, UserId},
-}, id::GuildId};
+    id::{ChannelId, UserId},
+}, id::{GuildId, RoleId}};
 use std::sync::{atomic::AtomicI64, Arc};
 
 #[derive(Debug, Clone)]

--- a/cache/src/models/guild.rs
+++ b/cache/src/models/guild.rs
@@ -1,8 +1,8 @@
-use rowifi_models::discord::{
+use rowifi_models::{discord::{
     datetime::Timestamp,
     guild::Permissions,
-    id::{ChannelId, GuildId, RoleId, UserId},
-};
+    id::{ChannelId, RoleId, UserId},
+}, id::GuildId};
 use std::sync::{atomic::AtomicI64, Arc};
 
 #[derive(Debug, Clone)]

--- a/cache/src/models/member.rs
+++ b/cache/src/models/member.rs
@@ -1,8 +1,7 @@
-use rowifi_models::discord::{
+use rowifi_models::{discord::{
     guild::{Member, PartialMember},
-    id::RoleId,
     user::User,
-};
+}, id::RoleId};
 use std::sync::Arc;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -15,12 +14,12 @@ pub struct CachedMember {
 
 impl PartialEq<Member> for CachedMember {
     fn eq(&self, other: &Member) -> bool {
-        (&self.roles, &self.nick) == (&other.roles, &other.nick)
+        (&self.roles.iter().map(|r| r.0).collect(), &self.nick) == (&other.roles, &other.nick)
     }
 }
 
 impl PartialEq<&PartialMember> for CachedMember {
     fn eq(&self, other: &&PartialMember) -> bool {
-        (&self.nick, &self.roles) == (&other.nick, &other.roles)
+        (&self.nick, &self.roles.iter().map(|r| r.0).collect()) == (&other.nick, &other.roles)
     }
 }

--- a/cache/src/models/member.rs
+++ b/cache/src/models/member.rs
@@ -1,7 +1,10 @@
-use rowifi_models::{discord::{
-    guild::{Member, PartialMember},
-    user::User,
-}, id::RoleId};
+use rowifi_models::{
+    discord::{
+        guild::{Member, PartialMember},
+        user::User,
+    },
+    id::RoleId,
+};
 use std::sync::Arc;
 
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/cache/src/models/role.rs
+++ b/cache/src/models/role.rs
@@ -1,7 +1,7 @@
-use rowifi_models::discord::{
+use rowifi_models::{discord::{
     guild::Permissions,
-    id::{GuildId, RoleId},
-};
+    id::RoleId,
+}, id::GuildId};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct CachedRole {

--- a/cache/src/models/role.rs
+++ b/cache/src/models/role.rs
@@ -1,7 +1,6 @@
 use rowifi_models::{discord::{
     guild::Permissions,
-    id::RoleId,
-}, id::GuildId};
+}, id::{GuildId, RoleId}};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct CachedRole {

--- a/cache/src/models/role.rs
+++ b/cache/src/models/role.rs
@@ -1,6 +1,7 @@
-use rowifi_models::{discord::{
-    guild::Permissions,
-}, id::{GuildId, RoleId}};
+use rowifi_models::{
+    discord::guild::Permissions,
+    id::{GuildId, RoleId},
+};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct CachedRole {

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -12,7 +12,7 @@ itertools = "0"
 rowifi-models =  { path = "../models" }
 rustls = "0.20"
 rustls-pemfile = "0"
-tokio-postgres = { version = "0", features = ["with-serde_json-1", "with-chrono-0_4"] }
+tokio-postgres = { version = "0", features = ["with-serde_json-1", "with-chrono-0_4", "with-uuid-0_8"] }
 tokio-postgres-rustls = "0"
 tracing = "0"
 webpki-roots = "0.22"

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -9,7 +9,7 @@ use itertools::Itertools;
 use rowifi_models::{
     guild::RoGuild,
     user::{RoGuildUser, RoUser},
-    FromRow, id::GuildId,
+    FromRow, id::{GuildId, UserId},
 };
 use rustls::{ClientConfig as RustlsConfig, OwnedTrustAnchor, RootCertStore};
 use rustls_pemfile::certs;
@@ -167,7 +167,7 @@ impl Database {
 
     pub async fn get_linked_user(
         &self,
-        user_id: i64,
+        user_id: UserId,
         guild_id: GuildId,
     ) -> Result<Option<RoGuildUser>, DatabaseError> {
         let client = self.get().await?;

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -9,7 +9,7 @@ use itertools::Itertools;
 use rowifi_models::{
     guild::RoGuild,
     user::{RoGuildUser, RoUser},
-    FromRow,
+    FromRow, id::GuildId,
 };
 use rustls::{ClientConfig as RustlsConfig, OwnedTrustAnchor, RootCertStore};
 use rustls_pemfile::certs;
@@ -124,7 +124,7 @@ impl Database {
         Ok(())
     }
 
-    pub async fn get_guild(&self, guild_id: i64) -> Result<RoGuild, DatabaseError> {
+    pub async fn get_guild(&self, guild_id: GuildId) -> Result<RoGuild, DatabaseError> {
         let client = self.get().await?;
         let statement = client
             .prepare_cached("SELECT * FROM guilds WHERE guild_id = $1")
@@ -168,7 +168,7 @@ impl Database {
     pub async fn get_linked_user(
         &self,
         user_id: i64,
-        guild_id: i64,
+        guild_id: GuildId,
     ) -> Result<Option<RoGuildUser>, DatabaseError> {
         let client = self.get().await?;
         let statement = client

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -8,8 +8,9 @@ use deadpool_postgres::{Manager, Object, Pool, Runtime};
 use itertools::Itertools;
 use rowifi_models::{
     guild::RoGuild,
+    id::{GuildId, UserId},
     user::{RoGuildUser, RoUser},
-    FromRow, id::{GuildId, UserId},
+    FromRow,
 };
 use rustls::{ClientConfig as RustlsConfig, OwnedTrustAnchor, RootCertStore};
 use rustls_pemfile::certs;

--- a/framework/src/arguments.rs
+++ b/framework/src/arguments.rs
@@ -2,9 +2,8 @@ use rowifi_models::{
     bind::AssetType,
     discord::{
         application::interaction::application_command::{CommandDataOption, CommandOptionValue},
-        id::{ChannelId, UserId},
     },
-    id::RoleId,
+    id::{RoleId, ChannelId, UserId},
     guild::BlacklistActionType,
 };
 use std::{num::ParseIntError, str::FromStr};
@@ -175,16 +174,16 @@ impl FromArg for UserId {
     type Error = ParseError;
     fn from_arg(arg: &str) -> Result<Self, Self::Error> {
         match parse_username(arg) {
-            Some(id) => Ok(UserId::new(id).unwrap()),
+            Some(id) => Ok(id),
             None => Err(ParseError("an User")),
         }
     }
 
     fn from_interaction(option: &CommandDataOption) -> Result<Self, Self::Error> {
         match &option.value {
-            CommandOptionValue::Integer(value) => Ok(UserId::new(*value as u64).unwrap()),
+            CommandOptionValue::Integer(value) => Ok(UserId::new(*value as u64)),
             CommandOptionValue::String(value) => Self::from_arg(value),
-            CommandOptionValue::User(value) => Ok(*value),
+            CommandOptionValue::User(value) => Ok(UserId(*value)),
             _ => unreachable!("UserId unreached"),
         }
     }
@@ -213,16 +212,16 @@ impl FromArg for ChannelId {
     type Error = ParseError;
     fn from_arg(arg: &str) -> Result<Self, Self::Error> {
         match parse_channel(arg) {
-            Some(id) => Ok(ChannelId::new(id).unwrap()),
+            Some(id) => Ok(id),
             None => Err(ParseError("a Channel")),
         }
     }
 
     fn from_interaction(option: &CommandDataOption) -> Result<Self, Self::Error> {
         match &option.value {
-            CommandOptionValue::Integer(value) => Ok(ChannelId::new(*value as u64).unwrap()),
+            CommandOptionValue::Integer(value) => Ok(ChannelId::new(*value as u64)),
             CommandOptionValue::String(value) => Self::from_arg(value),
-            CommandOptionValue::Channel(value) => Ok(*value),
+            CommandOptionValue::Channel(value) => Ok(ChannelId(*value)),
             _ => unreachable!("ChannelId unreached"),
         }
     }

--- a/framework/src/arguments.rs
+++ b/framework/src/arguments.rs
@@ -1,10 +1,10 @@
 use rowifi_models::{
     bind::AssetType,
-    discord::{
-        application::interaction::application_command::{CommandDataOption, CommandOptionValue},
+    discord::application::interaction::application_command::{
+        CommandDataOption, CommandOptionValue,
     },
-    id::{RoleId, ChannelId, UserId},
     guild::BlacklistActionType,
+    id::{ChannelId, RoleId, UserId},
 };
 use std::{num::ParseIntError, str::FromStr};
 

--- a/framework/src/arguments.rs
+++ b/framework/src/arguments.rs
@@ -2,8 +2,9 @@ use rowifi_models::{
     bind::AssetType,
     discord::{
         application::interaction::application_command::{CommandDataOption, CommandOptionValue},
-        id::{ChannelId, RoleId, UserId},
+        id::{ChannelId, UserId},
     },
+    id::RoleId,
     guild::BlacklistActionType,
 };
 use std::{num::ParseIntError, str::FromStr};
@@ -193,16 +194,16 @@ impl FromArg for RoleId {
     type Error = ParseError;
     fn from_arg(arg: &str) -> Result<Self, Self::Error> {
         match parse_role(arg) {
-            Some(id) => Ok(RoleId::new(id).unwrap()),
+            Some(id) => Ok(id),
             None => Err(ParseError("a Role")),
         }
     }
 
     fn from_interaction(option: &CommandDataOption) -> Result<Self, Self::Error> {
         match &option.value {
-            CommandOptionValue::Integer(value) => Ok(RoleId::new(*value as u64).unwrap()),
+            CommandOptionValue::Integer(value) => Ok(RoleId::new(*value as u64)),
             CommandOptionValue::String(value) => Self::from_arg(value),
-            CommandOptionValue::Role(value) => Ok(*value),
+            CommandOptionValue::Role(value) => Ok(RoleId(*value)),
             _ => unreachable!("RoleId unreached"),
         }
     }

--- a/framework/src/bucket.rs
+++ b/framework/src/bucket.rs
@@ -1,5 +1,5 @@
 use futures_util::future::{Future, FutureExt};
-use rowifi_models::discord::id::GuildId;
+use rowifi_models::id::GuildId;
 use std::{
     pin::Pin,
     sync::Arc,

--- a/framework/src/context.rs
+++ b/framework/src/context.rs
@@ -7,10 +7,10 @@ use rowifi_models::{
     discord::{
         application::interaction::application_command::CommandInteractionDataResolved,
         channel::embed::Embed,
-        id::{ChannelId, InteractionId, MessageId, UserId, WebhookId},
+        id::{InteractionId, MessageId, WebhookId},
         user::User,
     },
-    id::{GuildId, RoleId},
+    id::{GuildId, RoleId, ChannelId, UserId},
     stats::BotStats,
 };
 use std::{
@@ -188,7 +188,7 @@ impl CommandContext {
         if let Some(member) = self.bot.cache.member(guild_id, user_id) {
             return Ok(Some(member));
         }
-        let res = self.bot.http.guild_member(guild_id.0, user_id).exec().await;
+        let res = self.bot.http.guild_member(guild_id.0, user_id.0).exec().await;
         match res {
             Err(e) => {
                 if let DiscordErrorType::Response {
@@ -271,7 +271,7 @@ impl BotContext {
         if let Some(log_channel) = self.log_channels.get(&guild_id) {
             let _ = self
                 .http
-                .create_message(*log_channel)
+                .create_message(log_channel.0)
                 .embeds(&[embed])
                 .unwrap()
                 .exec()
@@ -281,7 +281,7 @@ impl BotContext {
             if let Some(channel_id) = log_channel {
                 let _ = self
                     .http
-                    .create_message(channel_id)
+                    .create_message(channel_id.0)
                     .embeds(&[embed])
                     .unwrap()
                     .exec()

--- a/framework/src/context.rs
+++ b/framework/src/context.rs
@@ -7,10 +7,10 @@ use rowifi_models::{
     discord::{
         application::interaction::application_command::CommandInteractionDataResolved,
         channel::embed::Embed,
-        id::{ChannelId, InteractionId, MessageId, RoleId, UserId, WebhookId},
+        id::{ChannelId, InteractionId, MessageId, UserId, WebhookId},
         user::User,
     },
-    id::GuildId,
+    id::{GuildId, RoleId},
     stats::BotStats,
 };
 use std::{

--- a/framework/src/context.rs
+++ b/framework/src/context.rs
@@ -7,9 +7,10 @@ use rowifi_models::{
     discord::{
         application::interaction::application_command::CommandInteractionDataResolved,
         channel::embed::Embed,
-        id::{ChannelId, GuildId, InteractionId, MessageId, RoleId, UserId, WebhookId},
+        id::{ChannelId, InteractionId, MessageId, RoleId, UserId, WebhookId},
         user::User,
     },
+    id::GuildId,
     stats::BotStats,
 };
 use std::{
@@ -187,7 +188,7 @@ impl CommandContext {
         if let Some(member) = self.bot.cache.member(guild_id, user_id) {
             return Ok(Some(member));
         }
-        let res = self.bot.http.guild_member(guild_id, user_id).exec().await;
+        let res = self.bot.http.guild_member(guild_id.0, user_id).exec().await;
         match res {
             Err(e) => {
                 if let DiscordErrorType::Response {

--- a/framework/src/context.rs
+++ b/framework/src/context.rs
@@ -10,7 +10,7 @@ use rowifi_models::{
         id::{InteractionId, MessageId, WebhookId},
         user::User,
     },
-    id::{GuildId, RoleId, ChannelId, UserId},
+    id::{ChannelId, GuildId, RoleId, UserId},
     stats::BotStats,
 };
 use std::{
@@ -188,7 +188,12 @@ impl CommandContext {
         if let Some(member) = self.bot.cache.member(guild_id, user_id) {
             return Ok(Some(member));
         }
-        let res = self.bot.http.guild_member(guild_id.0, user_id.0).exec().await;
+        let res = self
+            .bot
+            .http
+            .guild_member(guild_id.0, user_id.0)
+            .exec()
+            .await;
         match res {
             Err(e) => {
                 if let DiscordErrorType::Response {

--- a/framework/src/extensions/embed.rs
+++ b/framework/src/extensions/embed.rs
@@ -1,4 +1,4 @@
-use rowifi_models::discord::{datetime::Timestamp, id::RoleId};
+use rowifi_models::{discord::datetime::Timestamp, id::RoleId};
 use twilight_embed_builder::{EmbedBuilder, EmbedFieldBuilder, EmbedFooterBuilder};
 
 use crate::utils::Color;

--- a/framework/src/handler.rs
+++ b/framework/src/handler.rs
@@ -108,7 +108,7 @@ where
                     let _ = &ctx;
                     ctx.bot
                         .http
-                        .create_message(ctx.channel_id)
+                        .create_message(ctx.channel_id.0)
                         .embeds(&[embed])
                         .unwrap()
                         .exec()

--- a/framework/src/lib.rs
+++ b/framework/src/lib.rs
@@ -28,15 +28,18 @@ pub mod utils;
 use futures_util::future::{ready, Either, Ready};
 use itertools::Itertools;
 use rowifi_cache::{CachedGuild, CachedMember};
-use rowifi_models::{discord::{
-    application::{
-        callback::{CallbackData, InteractionResponse},
-        interaction::{application_command::CommandDataOption, Interaction},
+use rowifi_models::{
+    discord::{
+        application::{
+            callback::{CallbackData, InteractionResponse},
+            interaction::{application_command::CommandDataOption, Interaction},
+        },
+        channel::{message::MessageFlags, Message},
+        gateway::event::Event,
+        guild::Permissions,
     },
-    channel::{message::MessageFlags, Message},
-    gateway::event::Event,
-    guild::Permissions,
-}, id::{GuildId, ChannelId, UserId}};
+    id::{ChannelId, GuildId, UserId},
+};
 use std::{
     future::Future,
     pin::Pin,
@@ -318,7 +321,7 @@ impl Service<&Event> for Framework {
                     let ctx = CommandContext {
                         bot: self.bot.clone(),
                         channel_id: ChannelId(top_command.channel_id),
-                        guild_id: guild_id,
+                        guild_id,
                         author: Arc::new(user),
                         message_id: None,
                         interaction_id: Some(id),

--- a/framework/src/parser.rs
+++ b/framework/src/parser.rs
@@ -1,4 +1,4 @@
-use rowifi_models::discord::id::GuildId;
+use rowifi_models::id::GuildId;
 use uwl::Stream;
 
 use crate::context::BotContext;

--- a/framework/src/respond.rs
+++ b/framework/src/respond.rs
@@ -24,7 +24,7 @@ impl<'a> Responder<'a> {
     pub fn new(ctx: &'a CommandContext) -> Self {
         ctx.interaction_token.as_ref().map_or_else(
             || Self {
-                message: Some(ctx.bot.http.create_message(ctx.channel_id)),
+                message: Some(ctx.bot.http.create_message(ctx.channel_id.0)),
                 interaction: None,
                 followup: None,
             },

--- a/framework/src/utils.rs
+++ b/framework/src/utils.rs
@@ -18,7 +18,7 @@ use rowifi_models::{
         },
         channel::{embed::Embed, ReactionType},
         gateway::event::Event,
-    },
+    }, id::RoleId,
 };
 use std::{
     cmp::{max, min},
@@ -535,7 +535,7 @@ pub fn parse_username(mention: impl AsRef<str>) -> Option<u64> {
     }
 }
 
-pub fn parse_role(mention: impl AsRef<str>) -> Option<u64> {
+pub fn parse_role(mention: impl AsRef<str>) -> Option<RoleId> {
     let mention = mention.as_ref();
 
     if mention.len() < 4 {
@@ -544,9 +544,10 @@ pub fn parse_role(mention: impl AsRef<str>) -> Option<u64> {
 
     if mention.starts_with("<@&") && mention.ends_with('>') {
         let len = mention.len() - 1;
-        mention[3..len].parse::<u64>().ok()
+        let id = mention[3..len].parse::<u64>().ok();
+        id.map(|i| RoleId::new(i))
     } else if let Ok(r) = mention.parse::<u64>() {
-        Some(r)
+        Some(RoleId::new(r))
     } else {
         None
     }

--- a/framework/src/utils.rs
+++ b/framework/src/utils.rs
@@ -18,7 +18,7 @@ use rowifi_models::{
         },
         channel::{embed::Embed, ReactionType},
         gateway::event::Event,
-    }, id::RoleId,
+    }, id::{RoleId, UserId, ChannelId},
 };
 use std::{
     cmp::{max, min},
@@ -515,7 +515,7 @@ pub async fn paginate_embed(
     Ok(())
 }
 
-pub fn parse_username(mention: impl AsRef<str>) -> Option<u64> {
+pub fn parse_username(mention: impl AsRef<str>) -> Option<UserId> {
     let mention = mention.as_ref();
 
     if mention.len() < 4 {
@@ -524,12 +524,14 @@ pub fn parse_username(mention: impl AsRef<str>) -> Option<u64> {
 
     if mention.starts_with("<@!") {
         let len = mention.len() - 1;
-        mention[3..len].parse::<u64>().ok()
+        let id = mention[3..len].parse::<u64>().ok();
+        id.map(|i| UserId::new(i))
     } else if mention.starts_with("<@") {
         let len = mention.len() - 1;
-        mention[2..len].parse::<u64>().ok()
+        let id = mention[2..len].parse::<u64>().ok();
+        id.map(|i| UserId::new(i))
     } else if let Ok(r) = mention.parse::<u64>() {
-        Some(r)
+        Some(UserId::new(r))
     } else {
         None
     }
@@ -553,7 +555,7 @@ pub fn parse_role(mention: impl AsRef<str>) -> Option<RoleId> {
     }
 }
 
-pub fn parse_channel(mention: impl AsRef<str>) -> Option<u64> {
+pub fn parse_channel(mention: impl AsRef<str>) -> Option<ChannelId> {
     let mention = mention.as_ref();
 
     if mention.len() < 3 {
@@ -562,9 +564,10 @@ pub fn parse_channel(mention: impl AsRef<str>) -> Option<u64> {
 
     if mention.starts_with("<#") && mention.ends_with('>') {
         let len = mention.len() - 1;
-        mention[2..len].parse::<u64>().ok()
+        let id = mention[2..len].parse::<u64>().ok();
+        id.map(|i| ChannelId::new(i))
     } else if let Ok(r) = mention.parse::<u64>() {
-        Some(r)
+        Some(ChannelId::new(r))
     } else {
         None
     }

--- a/framework/src/utils.rs
+++ b/framework/src/utils.rs
@@ -18,7 +18,8 @@ use rowifi_models::{
         },
         channel::{embed::Embed, ReactionType},
         gateway::event::Event,
-    }, id::{RoleId, UserId, ChannelId},
+    },
+    id::{ChannelId, RoleId, UserId},
 };
 use std::{
     cmp::{max, min},

--- a/models/Cargo.toml
+++ b/models/Cargo.toml
@@ -10,10 +10,11 @@ bitflags = "1"
 bytes = "1"
 chrono = { version = "0", features = ["serde"] }
 lazy_static = "1"
-postgres-types = { version = "0", features = ["derive", "with-serde_json-1", "with-chrono-0_4"] }
+postgres-types = { version = "0", features = ["derive", "with-serde_json-1", "with-chrono-0_4", "with-uuid-0_8"] }
 prometheus = "0"
 regex = "1"
 serde = "1"
 serde_repr = "0"
-tokio-postgres = { version = "0", features = ["with-serde_json-1", "with-chrono-0_4"] }
+tokio-postgres = { version = "0", features = ["with-serde_json-1", "with-chrono-0_4", "with-uuid-0_8"] }
 twilight-model = { branch = "main", git = "https://github.com/twilight-rs/twilight" }
+uuid = { version = "0", features = ["serde"] }

--- a/models/src/bind/asset.rs
+++ b/models/src/bind/asset.rs
@@ -8,7 +8,7 @@ use std::{
     str::FromStr,
 };
 
-use crate::{FromRow, serialize_i64_as_string, serialize_vec_as_string};
+use crate::{FromRow, serialize_i64_as_string, id::RoleId};
 
 use super::template::Template;
 
@@ -23,8 +23,7 @@ pub struct Assetbind {
     /// The type of the Asset. Can be one of Asset, Badge, Gamepass
     pub asset_type: AssetType,
     /// The discord roles bounded to the asset
-    #[serde(serialize_with = "serialize_vec_as_string")]
-    pub discord_roles: Vec<i64>,
+    pub discord_roles: Vec<RoleId>,
     /// The number that decides whether this bind is chosen for the nickname
     pub priority: i32,
     /// The format of the nickname if this bind is chosen

--- a/models/src/bind/asset.rs
+++ b/models/src/bind/asset.rs
@@ -8,19 +8,22 @@ use std::{
     str::FromStr,
 };
 
-use crate::FromRow;
+use crate::{FromRow, serialize_i64_as_string, serialize_vec_as_string};
 
 use super::template::Template;
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Assetbind {
     /// The global id of the bind
+    #[serde(serialize_with = "serialize_i64_as_string")]
     pub bind_id: i64,
     /// The ID of the Roblox Asset
+    #[serde(serialize_with = "serialize_i64_as_string")]
     pub asset_id: i64,
     /// The type of the Asset. Can be one of Asset, Badge, Gamepass
     pub asset_type: AssetType,
     /// The discord roles bounded to the asset
+    #[serde(serialize_with = "serialize_vec_as_string")]
     pub discord_roles: Vec<i64>,
     /// The number that decides whether this bind is chosen for the nickname
     pub priority: i32,

--- a/models/src/bind/asset.rs
+++ b/models/src/bind/asset.rs
@@ -8,7 +8,7 @@ use std::{
     str::FromStr,
 };
 
-use crate::{FromRow, serialize_i64_as_string, id::RoleId};
+use crate::{id::RoleId, serialize_i64_as_string, FromRow};
 
 use super::template::Template;
 

--- a/models/src/bind/asset.rs
+++ b/models/src/bind/asset.rs
@@ -8,15 +8,17 @@ use std::{
     str::FromStr,
 };
 
-use crate::{id::RoleId, serialize_i64_as_string, FromRow};
+use crate::{
+    id::{BindId, RoleId},
+    serialize_i64_as_string, FromRow,
+};
 
 use super::template::Template;
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Assetbind {
     /// The global id of the bind
-    #[serde(serialize_with = "serialize_i64_as_string")]
-    pub bind_id: i64,
+    pub bind_id: BindId,
     /// The ID of the Roblox Asset
     #[serde(serialize_with = "serialize_i64_as_string")]
     pub asset_id: i64,

--- a/models/src/bind/custom.rs
+++ b/models/src/bind/custom.rs
@@ -6,7 +6,7 @@ use std::fmt::{Formatter, Result as FmtResult};
 
 use super::Template;
 
-use crate::{rolang::RoCommand, FromRow, serialize_i64_as_string, serialize_vec_as_string};
+use crate::{rolang::RoCommand, FromRow, serialize_i64_as_string, id::RoleId};
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct Custombind {
@@ -16,8 +16,7 @@ pub struct Custombind {
     /// The ID of the Custom Bind
     pub custom_bind_id: i32,
     /// The discord roles bound to the custombind
-    #[serde(serialize_with = "serialize_vec_as_string")]
-    pub discord_roles: Vec<i64>,
+    pub discord_roles: Vec<RoleId>,
     /// The code of the bind
     pub code: String,
     /// The number that decides whether this bind is chosen for the nickname

--- a/models/src/bind/custom.rs
+++ b/models/src/bind/custom.rs
@@ -6,7 +6,7 @@ use std::fmt::{Formatter, Result as FmtResult};
 
 use super::Template;
 
-use crate::{rolang::RoCommand, FromRow, serialize_i64_as_string, id::RoleId};
+use crate::{id::RoleId, rolang::RoCommand, serialize_i64_as_string, FromRow};
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct Custombind {

--- a/models/src/bind/custom.rs
+++ b/models/src/bind/custom.rs
@@ -6,15 +6,17 @@ use std::fmt::{Formatter, Result as FmtResult};
 
 use super::Template;
 
-use crate::{rolang::RoCommand, FromRow};
+use crate::{rolang::RoCommand, FromRow, serialize_i64_as_string, serialize_vec_as_string};
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct Custombind {
     /// The global id of the bind
+    #[serde(serialize_with = "serialize_i64_as_string")]
     pub bind_id: i64,
     /// The ID of the Custom Bind
     pub custom_bind_id: i32,
     /// The discord roles bound to the custombind
+    #[serde(serialize_with = "serialize_vec_as_string")]
     pub discord_roles: Vec<i64>,
     /// The code of the bind
     pub code: String,

--- a/models/src/bind/custom.rs
+++ b/models/src/bind/custom.rs
@@ -6,13 +6,16 @@ use std::fmt::{Formatter, Result as FmtResult};
 
 use super::Template;
 
-use crate::{id::RoleId, rolang::RoCommand, serialize_i64_as_string, FromRow};
+use crate::{
+    id::{BindId, RoleId},
+    rolang::RoCommand,
+    FromRow,
+};
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct Custombind {
     /// The global id of the bind
-    #[serde(serialize_with = "serialize_i64_as_string")]
-    pub bind_id: i64,
+    pub bind_id: BindId,
     /// The ID of the Custom Bind
     pub custom_bind_id: i32,
     /// The discord roles bound to the custombind

--- a/models/src/bind/group.rs
+++ b/models/src/bind/group.rs
@@ -2,13 +2,15 @@ use serde::{Deserialize, Serialize};
 
 use super::Template;
 
-use crate::{id::RoleId, serialize_i64_as_string, FromRow};
+use crate::{
+    id::{BindId, RoleId},
+    serialize_i64_as_string, FromRow,
+};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Groupbind {
     /// The global id of the bind
-    #[serde(serialize_with = "serialize_i64_as_string")]
-    pub bind_id: i64,
+    pub bind_id: BindId,
     /// The Id of the Roblox Group
     #[serde(serialize_with = "serialize_i64_as_string")]
     pub group_id: i64,

--- a/models/src/bind/group.rs
+++ b/models/src/bind/group.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use super::Template;
 
-use crate::{FromRow, serialize_i64_as_string, serialize_vec_as_string};
+use crate::{FromRow, serialize_i64_as_string, id::RoleId};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Groupbind {
@@ -13,8 +13,7 @@ pub struct Groupbind {
     #[serde(serialize_with = "serialize_i64_as_string")]
     pub group_id: i64,
     /// The discord roles bound to the group
-    #[serde(serialize_with = "serialize_vec_as_string")]
-    pub discord_roles: Vec<i64>,
+    pub discord_roles: Vec<RoleId>,
     /// The number that decides whether this bind is chosen for the nickname
     pub priority: i32,
     /// The format of the nickname if this bind is chosen

--- a/models/src/bind/group.rs
+++ b/models/src/bind/group.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use super::Template;
 
-use crate::{FromRow, serialize_i64_as_string, id::RoleId};
+use crate::{id::RoleId, serialize_i64_as_string, FromRow};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Groupbind {

--- a/models/src/bind/group.rs
+++ b/models/src/bind/group.rs
@@ -2,15 +2,18 @@ use serde::{Deserialize, Serialize};
 
 use super::Template;
 
-use crate::FromRow;
+use crate::{FromRow, serialize_i64_as_string, serialize_vec_as_string};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Groupbind {
     /// The global id of the bind
+    #[serde(serialize_with = "serialize_i64_as_string")]
     pub bind_id: i64,
     /// The Id of the Roblox Group
+    #[serde(serialize_with = "serialize_i64_as_string")]
     pub group_id: i64,
     /// The discord roles bound to the group
+    #[serde(serialize_with = "serialize_vec_as_string")]
     pub discord_roles: Vec<i64>,
     /// The number that decides whether this bind is chosen for the nickname
     pub priority: i32,

--- a/models/src/bind/mod.rs
+++ b/models/src/bind/mod.rs
@@ -14,7 +14,7 @@ use bytes::BytesMut;
 use postgres_types::{to_sql_checked, FromSql, IsNull, ToSql, Type};
 use serde::{Deserialize, Serialize};
 
-use crate::{roblox::user::PartialUser as RobloxUser, user::RoGuildUser, FromRow};
+use crate::{roblox::user::PartialUser as RobloxUser, user::RoGuildUser, FromRow, id::RoleId};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(untagged)]
@@ -70,7 +70,7 @@ impl Bind {
     }
 
     #[must_use]
-    pub fn discord_roles(&self) -> &[i64] {
+    pub fn discord_roles(&self) -> &[RoleId] {
         match self {
             Bind::Rank(r) => &r.discord_roles,
             Bind::Group(g) => &g.discord_roles,

--- a/models/src/bind/mod.rs
+++ b/models/src/bind/mod.rs
@@ -14,7 +14,7 @@ use bytes::BytesMut;
 use postgres_types::{to_sql_checked, FromSql, IsNull, ToSql, Type};
 use serde::{Deserialize, Serialize};
 
-use crate::{roblox::user::PartialUser as RobloxUser, user::RoGuildUser, FromRow, id::RoleId};
+use crate::{id::RoleId, roblox::user::PartialUser as RobloxUser, user::RoGuildUser, FromRow};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(untagged)]

--- a/models/src/bind/rank.rs
+++ b/models/src/bind/rank.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{FromRow, serialize_i64_as_string, serialize_vec_as_string};
+use crate::{FromRow, serialize_i64_as_string, id::RoleId};
 
 use super::template::Template;
 
@@ -13,8 +13,7 @@ pub struct Rankbind {
     #[serde(serialize_with = "serialize_i64_as_string")]
     pub group_id: i64,
     /// The discord roles bound to the rank
-    #[serde(serialize_with = "serialize_vec_as_string")]
-    pub discord_roles: Vec<i64>,
+    pub discord_roles: Vec<RoleId>,
     /// The Id of the rank in the group (0-255)
     #[serde(serialize_with = "serialize_i64_as_string")]
     pub group_rank_id: i64,

--- a/models/src/bind/rank.rs
+++ b/models/src/bind/rank.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{FromRow, serialize_i64_as_string, id::RoleId};
+use crate::{id::RoleId, serialize_i64_as_string, FromRow};
 
 use super::template::Template;
 

--- a/models/src/bind/rank.rs
+++ b/models/src/bind/rank.rs
@@ -1,20 +1,25 @@
 use serde::{Deserialize, Serialize};
 
-use crate::FromRow;
+use crate::{FromRow, serialize_i64_as_string, serialize_vec_as_string};
 
 use super::template::Template;
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Rankbind {
     /// The global id of the bind
+    #[serde(serialize_with = "serialize_i64_as_string")]
     pub bind_id: i64,
     /// The Id of the Group
+    #[serde(serialize_with = "serialize_i64_as_string")]
     pub group_id: i64,
     /// The discord roles bound to the rank
+    #[serde(serialize_with = "serialize_vec_as_string")]
     pub discord_roles: Vec<i64>,
     /// The Id of the rank in the group (0-255)
+    #[serde(serialize_with = "serialize_i64_as_string")]
     pub group_rank_id: i64,
     /// The global id of the rank
+    #[serde(serialize_with = "serialize_i64_as_string")]
     pub roblox_rank_id: i64,
     /// The number that decides whether this bind is chosen for the nickname
     pub priority: i32,

--- a/models/src/bind/rank.rs
+++ b/models/src/bind/rank.rs
@@ -1,14 +1,16 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{id::RoleId, serialize_i64_as_string, FromRow};
+use crate::{
+    id::{BindId, RoleId},
+    serialize_i64_as_string, FromRow,
+};
 
 use super::template::Template;
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Rankbind {
     /// The global id of the bind
-    #[serde(serialize_with = "serialize_i64_as_string")]
-    pub bind_id: i64,
+    pub bind_id: BindId,
     /// The Id of the Group
     #[serde(serialize_with = "serialize_i64_as_string")]
     pub group_id: i64,

--- a/models/src/blacklist.rs
+++ b/models/src/blacklist.rs
@@ -1,6 +1,7 @@
 use bytes::BytesMut;
 use postgres_types::{to_sql_checked, FromSql, IsNull, ToSql, Type};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
 use crate::rolang::{RoCommand, RoCommandUser};
@@ -19,7 +20,7 @@ pub enum BlacklistData {
     Custom(RoCommand),
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Ord, PartialEq, PartialOrd, Serialize_repr)]
 #[repr(u8)]
 #[non_exhaustive]
 pub enum BlacklistType {

--- a/models/src/events.rs
+++ b/models/src/events.rs
@@ -1,12 +1,12 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::FromRow;
+use crate::{FromRow, id::GuildId};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct EventLog {
     pub event_id: i64,
-    pub guild_id: i64,
+    pub guild_id: GuildId,
     pub event_type: i32,
     pub guild_event_id: i64,
     pub host_id: i64,
@@ -19,7 +19,7 @@ pub struct EventLog {
 pub struct EventType {
     pub event_type_id: i64,
     pub event_type_guild_id: i32,
-    pub guild_id: i64,
+    pub guild_id: GuildId,
     pub name: String,
     pub disabled: bool,
 }

--- a/models/src/events.rs
+++ b/models/src/events.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::{FromRow, id::GuildId};
+use crate::{id::GuildId, FromRow};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct EventLog {

--- a/models/src/events.rs
+++ b/models/src/events.rs
@@ -1,11 +1,11 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::{id::GuildId, FromRow};
+use crate::{id::{GuildId, EventId, EventTypeId}, FromRow};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct EventLog {
-    pub event_id: i64,
+    pub event_id: EventId,
     pub guild_id: GuildId,
     pub event_type: i32,
     pub guild_event_id: i64,
@@ -17,7 +17,7 @@ pub struct EventLog {
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct EventType {
-    pub event_type_id: i64,
+    pub event_type_id: EventTypeId,
     pub event_type_guild_id: i32,
     pub guild_id: GuildId,
     pub name: String,

--- a/models/src/guild/backup.rs
+++ b/models/src/guild/backup.rs
@@ -1,14 +1,14 @@
 use postgres_types::Json;
 use serde::{Deserialize, Serialize};
 
-use crate::{bind::BindBackup, blacklist::Blacklist, FromRow};
+use crate::{bind::BindBackup, blacklist::Blacklist, FromRow, id::UserId};
 
 use super::BlacklistActionType;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct GuildBackup {
     pub backup_id: i64,
-    pub discord_id: i64,
+    pub discord_id: UserId,
     pub name: String,
     pub data: Json<GuildBackupData>,
 }

--- a/models/src/guild/backup.rs
+++ b/models/src/guild/backup.rs
@@ -1,7 +1,7 @@
 use postgres_types::Json;
 use serde::{Deserialize, Serialize};
 
-use crate::{bind::BindBackup, blacklist::Blacklist, FromRow, id::UserId};
+use crate::{bind::BindBackup, blacklist::Blacklist, id::UserId, FromRow};
 
 use super::BlacklistActionType;
 

--- a/models/src/guild/backup.rs
+++ b/models/src/guild/backup.rs
@@ -1,13 +1,13 @@
 use postgres_types::Json;
 use serde::{Deserialize, Serialize};
 
-use crate::{bind::BindBackup, blacklist::Blacklist, id::UserId, FromRow};
+use crate::{bind::BindBackup, blacklist::Blacklist, id::{UserId, BackupId}, FromRow};
 
 use super::BlacklistActionType;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct GuildBackup {
-    pub backup_id: i64,
+    pub backup_id: BackupId,
     pub discord_id: UserId,
     pub name: String,
     pub data: Json<GuildBackupData>,

--- a/models/src/guild/mod.rs
+++ b/models/src/guild/mod.rs
@@ -3,7 +3,7 @@ mod types;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{blacklist::Blacklist, FromRow, serialize_vec_as_string, serialize_option_as_string, id::GuildId};
+use crate::{blacklist::Blacklist, FromRow, serialize_vec_as_string, serialize_option_as_string, id::{GuildId, RoleId}};
 
 pub use types::{BlacklistActionType, GuildType};
 
@@ -16,12 +16,10 @@ pub struct RoGuild {
     pub command_prefix: String,
 
     /// The role meant for unverified users in the guild
-    #[serde(serialize_with = "serialize_vec_as_string")]
-    pub verification_roles: Vec<i64>,
+    pub verification_roles: Vec<RoleId>,
 
     /// The role meant for verified users in the guild
-    #[serde(serialize_with = "serialize_vec_as_string")]
-    pub verified_roles: Vec<i64>,
+    pub verified_roles: Vec<RoleId>,
 
     /// The array containing all the [Blacklist] of the guild
     pub blacklists: Vec<Blacklist>,
@@ -45,17 +43,13 @@ pub struct RoGuild {
 
     pub update_on_join: bool,
 
-    #[serde(serialize_with = "serialize_vec_as_string")]
-    pub admin_roles: Vec<i64>,
+    pub admin_roles: Vec<RoleId>,
 
-    #[serde(serialize_with = "serialize_vec_as_string")]
-    pub trainer_roles: Vec<i64>,
+    pub trainer_roles: Vec<RoleId>,
 
-    #[serde(serialize_with = "serialize_vec_as_string")]
-    pub bypass_roles: Vec<i64>,
+    pub bypass_roles: Vec<RoleId>,
 
-    #[serde(serialize_with = "serialize_vec_as_string")]
-    pub nickname_bypass_roles: Vec<i64>,
+    pub nickname_bypass_roles: Vec<RoleId>,
 
     #[serde(serialize_with = "serialize_option_as_string")]
     pub log_channel: Option<i64>,

--- a/models/src/guild/mod.rs
+++ b/models/src/guild/mod.rs
@@ -3,15 +3,14 @@ mod types;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{blacklist::Blacklist, FromRow, serialize_i64_as_string, serialize_vec_as_string, serialize_option_as_string};
+use crate::{blacklist::Blacklist, FromRow, serialize_vec_as_string, serialize_option_as_string, id::GuildId};
 
 pub use types::{BlacklistActionType, GuildType};
 
-#[derive(Clone, Debug, Deserialize, Default, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RoGuild {
     /// The id of the guild
-    #[serde(serialize_with = "serialize_i64_as_string")]
-    pub guild_id: i64,
+    pub guild_id: GuildId,
 
     /// The prefix that is to be used by every command run in the guild
     pub command_prefix: String,
@@ -64,11 +63,25 @@ pub struct RoGuild {
 
 impl RoGuild {
     #[must_use]
-    pub fn new(guild_id: i64) -> Self {
+    pub fn new(guild_id: GuildId) -> Self {
         Self {
             guild_id,
             command_prefix: "!".into(),
-            ..RoGuild::default()
+            verification_roles: Vec::new(),
+            verified_roles: Vec::new(),
+            blacklists: Vec::new(),
+            disabled_channels: Vec::new(),
+            registered_groups: Vec::new(),
+            auto_detection: false,
+            kind: GuildType::Free,
+            premium_owner: None,
+            blacklist_action: BlacklistActionType::None,
+            update_on_join: false,
+            admin_roles: Vec::new(),
+            trainer_roles: Vec::new(),
+            bypass_roles: Vec::new(),
+            nickname_bypass_roles: Vec::new(),
+            log_channel: None,
         }
     }
 }

--- a/models/src/guild/mod.rs
+++ b/models/src/guild/mod.rs
@@ -3,7 +3,11 @@ mod types;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{blacklist::Blacklist, FromRow, serialize_vec_as_string, id::{GuildId, RoleId, ChannelId, UserId}};
+use crate::{
+    blacklist::Blacklist,
+    id::{ChannelId, GuildId, RoleId, UserId},
+    serialize_vec_as_string, FromRow,
+};
 
 pub use types::{BlacklistActionType, GuildType};
 

--- a/models/src/guild/mod.rs
+++ b/models/src/guild/mod.rs
@@ -3,7 +3,7 @@ mod types;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{blacklist::Blacklist, FromRow, serialize_vec_as_string, serialize_option_as_string, id::{GuildId, RoleId}};
+use crate::{blacklist::Blacklist, FromRow, serialize_vec_as_string, id::{GuildId, RoleId, ChannelId, UserId}};
 
 pub use types::{BlacklistActionType, GuildType};
 
@@ -25,8 +25,7 @@ pub struct RoGuild {
     pub blacklists: Vec<Blacklist>,
 
     /// The list of channels where commands are disabled
-    #[serde(serialize_with = "serialize_vec_as_string")]
-    pub disabled_channels: Vec<i64>,
+    pub disabled_channels: Vec<ChannelId>,
 
     /// The list of groups that the guild uses for analytics
     #[serde(serialize_with = "serialize_vec_as_string")]
@@ -36,8 +35,7 @@ pub struct RoGuild {
 
     pub kind: GuildType,
 
-    #[serde(serialize_with = "serialize_option_as_string")]
-    pub premium_owner: Option<i64>,
+    pub premium_owner: Option<UserId>,
 
     pub blacklist_action: BlacklistActionType,
 
@@ -51,8 +49,7 @@ pub struct RoGuild {
 
     pub nickname_bypass_roles: Vec<RoleId>,
 
-    #[serde(serialize_with = "serialize_option_as_string")]
-    pub log_channel: Option<i64>,
+    pub log_channel: Option<ChannelId>,
 }
 
 impl RoGuild {

--- a/models/src/guild/mod.rs
+++ b/models/src/guild/mod.rs
@@ -3,51 +3,62 @@ mod types;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{blacklist::Blacklist, FromRow};
+use crate::{blacklist::Blacklist, FromRow, serialize_i64_as_string, serialize_vec_as_string, serialize_option_as_string};
 
 pub use types::{BlacklistActionType, GuildType};
 
 #[derive(Clone, Debug, Deserialize, Default, Serialize)]
 pub struct RoGuild {
     /// The id of the guild
+    #[serde(serialize_with = "serialize_i64_as_string")]
     pub guild_id: i64,
 
     /// The prefix that is to be used by every command run in the guild
     pub command_prefix: String,
 
     /// The role meant for unverified users in the guild
+    #[serde(serialize_with = "serialize_vec_as_string")]
     pub verification_roles: Vec<i64>,
 
     /// The role meant for verified users in the guild
+    #[serde(serialize_with = "serialize_vec_as_string")]
     pub verified_roles: Vec<i64>,
 
     /// The array containing all the [Blacklist] of the guild
     pub blacklists: Vec<Blacklist>,
 
     /// The list of channels where commands are disabled
+    #[serde(serialize_with = "serialize_vec_as_string")]
     pub disabled_channels: Vec<i64>,
 
     /// The list of groups that the guild uses for analytics
+    #[serde(serialize_with = "serialize_vec_as_string")]
     pub registered_groups: Vec<i64>,
 
     pub auto_detection: bool,
 
     pub kind: GuildType,
 
+    #[serde(serialize_with = "serialize_option_as_string")]
     pub premium_owner: Option<i64>,
 
     pub blacklist_action: BlacklistActionType,
 
     pub update_on_join: bool,
 
+    #[serde(serialize_with = "serialize_vec_as_string")]
     pub admin_roles: Vec<i64>,
 
+    #[serde(serialize_with = "serialize_vec_as_string")]
     pub trainer_roles: Vec<i64>,
 
+    #[serde(serialize_with = "serialize_vec_as_string")]
     pub bypass_roles: Vec<i64>,
 
+    #[serde(serialize_with = "serialize_vec_as_string")]
     pub nickname_bypass_roles: Vec<i64>,
 
+    #[serde(serialize_with = "serialize_option_as_string")]
     pub log_channel: Option<i64>,
 }
 

--- a/models/src/id.rs
+++ b/models/src/id.rs
@@ -9,6 +9,7 @@ use twilight_model::id::{
     ChannelId as DiscordChannelId, GuildId as DiscordGuildId, RoleId as DiscordRoleId,
     UserId as DiscordUserId,
 };
+use uuid::Uuid;
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct GuildId(pub DiscordGuildId);
@@ -21,6 +22,11 @@ pub struct RoleId(pub DiscordRoleId);
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct ChannelId(pub DiscordChannelId);
+
+#[derive(
+    Clone, Copy, Debug, Default, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize,
+)]
+pub struct BindId(pub Uuid);
 
 impl GuildId {
     pub fn new(n: u64) -> Self {
@@ -81,6 +87,12 @@ impl Display for RoleId {
 }
 
 impl Display for ChannelId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        Display::fmt(&self.0, f)
+    }
+}
+
+impl Display for BindId {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         Display::fmt(&self.0, f)
     }
@@ -150,6 +162,22 @@ impl ToSql for ChannelId {
     to_sql_checked!();
 }
 
+impl ToSql for BindId {
+    fn to_sql(
+        &self,
+        ty: &Type,
+        out: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn StdError + Sync + Send>> {
+        Uuid::to_sql(&self.0, ty, out)
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        <Uuid as ToSql>::accepts(ty)
+    }
+
+    to_sql_checked!();
+}
+
 impl<'a> FromSql<'a> for GuildId {
     fn from_sql(ty: &Type, raw: &'a [u8]) -> Result<Self, Box<dyn StdError + Sync + Send>> {
         let id = i64::from_sql(ty, raw)?;
@@ -191,5 +219,16 @@ impl<'a> FromSql<'a> for ChannelId {
 
     fn accepts(ty: &Type) -> bool {
         <i64 as FromSql>::accepts(ty)
+    }
+}
+
+impl<'a> FromSql<'a> for BindId {
+    fn from_sql(ty: &Type, raw: &'a [u8]) -> Result<Self, Box<dyn StdError + Sync + Send>> {
+        let id = Uuid::from_sql(ty, raw)?;
+        Ok(Self(id))
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        <Uuid as FromSql>::accepts(ty)
     }
 }

--- a/models/src/id.rs
+++ b/models/src/id.rs
@@ -2,7 +2,7 @@ use postgres_types::{ToSql, Type, IsNull, to_sql_checked, FromSql};
 use std::{error::Error as StdError, fmt::{Display, Formatter, Result as FmtResult}};
 use bytes::BytesMut;
 use serde::{Deserialize, Serialize};
-use twilight_model::id::{GuildId as DiscordGuildId, UserId as DiscordUserId, RoleId as DiscordRoleId};
+use twilight_model::id::{GuildId as DiscordGuildId, UserId as DiscordUserId, RoleId as DiscordRoleId, ChannelId as DiscordChannelId};
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct GuildId(pub DiscordGuildId);
@@ -12,6 +12,9 @@ pub struct UserId(pub DiscordUserId);
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct RoleId(pub DiscordRoleId);
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct ChannelId(pub DiscordChannelId);
 
 impl GuildId {
     pub fn new(n: u64) -> Self {
@@ -43,6 +46,16 @@ impl RoleId {
     }
 }
 
+impl ChannelId {
+    pub fn new(n: u64) -> Self {
+        Self(DiscordChannelId::new(n).unwrap())
+    }
+
+    pub const fn get(self) -> u64 {
+        self.0.get()
+    }
+}
+
 impl Display for GuildId {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         Display::fmt(&self.0, f)
@@ -56,6 +69,12 @@ impl Display for UserId {
 }
 
 impl Display for RoleId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        Display::fmt(&self.0, f)
+    }
+}
+
+impl Display for ChannelId {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         Display::fmt(&self.0, f)
     }
@@ -97,6 +116,18 @@ impl ToSql for RoleId {
     to_sql_checked!();
 }
 
+impl ToSql for ChannelId {
+    fn to_sql(&self, ty: &Type, out: &mut BytesMut) -> Result<IsNull, Box<dyn StdError + Sync + Send>> {
+        i64::to_sql(&(self.get() as i64), ty, out)
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        <i64 as ToSql>::accepts(ty)
+    }
+
+    to_sql_checked!();
+}
+
 impl<'a> FromSql<'a> for GuildId {
     fn from_sql(ty: &Type, raw: &'a [u8]) -> Result<Self, Box<dyn StdError + Sync + Send>> {
         let id = i64::from_sql(ty, raw)?;
@@ -120,6 +151,17 @@ impl<'a> FromSql<'a> for UserId {
 }
 
 impl<'a> FromSql<'a> for RoleId {
+    fn from_sql(ty: &Type, raw: &'a [u8]) -> Result<Self, Box<dyn StdError + Sync + Send>> {
+        let id = i64::from_sql(ty, raw)?;
+        Ok(Self::new(id as u64))
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        <i64 as FromSql>::accepts(ty)
+    }
+}
+
+impl<'a> FromSql<'a> for ChannelId {
     fn from_sql(ty: &Type, raw: &'a [u8]) -> Result<Self, Box<dyn StdError + Sync + Send>> {
         let id = i64::from_sql(ty, raw)?;
         Ok(Self::new(id as u64))

--- a/models/src/id.rs
+++ b/models/src/id.rs
@@ -1,0 +1,47 @@
+use postgres_types::{ToSql, Type, IsNull, to_sql_checked, FromSql};
+use std::{error::Error as StdError, fmt::{Display, Formatter, Result as FmtResult}};
+use bytes::BytesMut;
+use serde::{Deserialize, Serialize};
+use twilight_model::id::GuildId as DiscordGuildId;
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct GuildId(pub DiscordGuildId);
+
+impl GuildId {
+    pub fn new(n: u64) -> Self {
+        Self(DiscordGuildId::new(n).unwrap())
+    }
+
+    pub const fn get(self) -> u64 {
+        self.0.get()
+    }
+}
+
+impl Display for GuildId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        Display::fmt(&self.0, f)
+    }
+}
+
+impl ToSql for GuildId {
+    fn to_sql(&self, ty: &Type, out: &mut BytesMut) -> Result<IsNull, Box<dyn StdError + Sync + Send>> {
+        i64::to_sql(&(self.get() as i64), ty, out)
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        <i64 as ToSql>::accepts(ty)
+    }
+
+    to_sql_checked!();
+}
+
+impl<'a> FromSql<'a> for GuildId {
+    fn from_sql(ty: &Type, raw: &'a [u8]) -> Result<Self, Box<dyn StdError + Sync + Send>> {
+        let id = i64::from_sql(ty, raw)?;
+        Ok(Self::new(id as u64))
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        <i64 as FromSql>::accepts(ty)
+    }
+}

--- a/models/src/id.rs
+++ b/models/src/id.rs
@@ -1,8 +1,14 @@
-use postgres_types::{ToSql, Type, IsNull, to_sql_checked, FromSql};
-use std::{error::Error as StdError, fmt::{Display, Formatter, Result as FmtResult}};
 use bytes::BytesMut;
+use postgres_types::{to_sql_checked, FromSql, IsNull, ToSql, Type};
 use serde::{Deserialize, Serialize};
-use twilight_model::id::{GuildId as DiscordGuildId, UserId as DiscordUserId, RoleId as DiscordRoleId, ChannelId as DiscordChannelId};
+use std::{
+    error::Error as StdError,
+    fmt::{Display, Formatter, Result as FmtResult},
+};
+use twilight_model::id::{
+    ChannelId as DiscordChannelId, GuildId as DiscordGuildId, RoleId as DiscordRoleId,
+    UserId as DiscordUserId,
+};
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct GuildId(pub DiscordGuildId);
@@ -81,7 +87,11 @@ impl Display for ChannelId {
 }
 
 impl ToSql for GuildId {
-    fn to_sql(&self, ty: &Type, out: &mut BytesMut) -> Result<IsNull, Box<dyn StdError + Sync + Send>> {
+    fn to_sql(
+        &self,
+        ty: &Type,
+        out: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn StdError + Sync + Send>> {
         i64::to_sql(&(self.get() as i64), ty, out)
     }
 
@@ -93,7 +103,11 @@ impl ToSql for GuildId {
 }
 
 impl ToSql for UserId {
-    fn to_sql(&self, ty: &Type, out: &mut BytesMut) -> Result<IsNull, Box<dyn StdError + Sync + Send>> {
+    fn to_sql(
+        &self,
+        ty: &Type,
+        out: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn StdError + Sync + Send>> {
         i64::to_sql(&(self.get() as i64), ty, out)
     }
 
@@ -105,7 +119,11 @@ impl ToSql for UserId {
 }
 
 impl ToSql for RoleId {
-    fn to_sql(&self, ty: &Type, out: &mut BytesMut) -> Result<IsNull, Box<dyn StdError + Sync + Send>> {
+    fn to_sql(
+        &self,
+        ty: &Type,
+        out: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn StdError + Sync + Send>> {
         i64::to_sql(&(self.get() as i64), ty, out)
     }
 
@@ -117,7 +135,11 @@ impl ToSql for RoleId {
 }
 
 impl ToSql for ChannelId {
-    fn to_sql(&self, ty: &Type, out: &mut BytesMut) -> Result<IsNull, Box<dyn StdError + Sync + Send>> {
+    fn to_sql(
+        &self,
+        ty: &Type,
+        out: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn StdError + Sync + Send>> {
         i64::to_sql(&(self.get() as i64), ty, out)
     }
 

--- a/models/src/id.rs
+++ b/models/src/id.rs
@@ -28,6 +28,21 @@ pub struct ChannelId(pub DiscordChannelId);
 )]
 pub struct BindId(pub Uuid);
 
+#[derive(
+    Clone, Copy, Debug, Default, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize,
+)]
+pub struct BackupId(pub Uuid);
+
+#[derive(
+    Clone, Copy, Debug, Default, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize,
+)]
+pub struct EventId(pub Uuid);
+
+#[derive(
+    Clone, Copy, Debug, Default, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize,
+)]
+pub struct EventTypeId(pub Uuid);
+
 impl GuildId {
     pub fn new(n: u64) -> Self {
         Self(DiscordGuildId::new(n).unwrap())
@@ -93,6 +108,24 @@ impl Display for ChannelId {
 }
 
 impl Display for BindId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        Display::fmt(&self.0, f)
+    }
+}
+
+impl Display for BackupId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        Display::fmt(&self.0, f)
+    }
+}
+
+impl Display for EventId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        Display::fmt(&self.0, f)
+    }
+}
+
+impl Display for EventTypeId {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         Display::fmt(&self.0, f)
     }
@@ -178,6 +211,54 @@ impl ToSql for BindId {
     to_sql_checked!();
 }
 
+impl ToSql for BackupId {
+    fn to_sql(
+        &self,
+        ty: &Type,
+        out: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn StdError + Sync + Send>> {
+        Uuid::to_sql(&self.0, ty, out)
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        <Uuid as ToSql>::accepts(ty)
+    }
+
+    to_sql_checked!();
+}
+
+impl ToSql for EventId {
+    fn to_sql(
+        &self,
+        ty: &Type,
+        out: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn StdError + Sync + Send>> {
+        Uuid::to_sql(&self.0, ty, out)
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        <Uuid as ToSql>::accepts(ty)
+    }
+
+    to_sql_checked!();
+}
+
+impl ToSql for EventTypeId {
+    fn to_sql(
+        &self,
+        ty: &Type,
+        out: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn StdError + Sync + Send>> {
+        Uuid::to_sql(&self.0, ty, out)
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        <Uuid as ToSql>::accepts(ty)
+    }
+
+    to_sql_checked!();
+}
+
 impl<'a> FromSql<'a> for GuildId {
     fn from_sql(ty: &Type, raw: &'a [u8]) -> Result<Self, Box<dyn StdError + Sync + Send>> {
         let id = i64::from_sql(ty, raw)?;
@@ -223,6 +304,39 @@ impl<'a> FromSql<'a> for ChannelId {
 }
 
 impl<'a> FromSql<'a> for BindId {
+    fn from_sql(ty: &Type, raw: &'a [u8]) -> Result<Self, Box<dyn StdError + Sync + Send>> {
+        let id = Uuid::from_sql(ty, raw)?;
+        Ok(Self(id))
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        <Uuid as FromSql>::accepts(ty)
+    }
+}
+
+impl<'a> FromSql<'a> for BackupId {
+    fn from_sql(ty: &Type, raw: &'a [u8]) -> Result<Self, Box<dyn StdError + Sync + Send>> {
+        let id = Uuid::from_sql(ty, raw)?;
+        Ok(Self(id))
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        <Uuid as FromSql>::accepts(ty)
+    }
+}
+
+impl<'a> FromSql<'a> for EventId {
+    fn from_sql(ty: &Type, raw: &'a [u8]) -> Result<Self, Box<dyn StdError + Sync + Send>> {
+        let id = Uuid::from_sql(ty, raw)?;
+        Ok(Self(id))
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        <Uuid as FromSql>::accepts(ty)
+    }
+}
+
+impl<'a> FromSql<'a> for EventTypeId {
     fn from_sql(ty: &Type, raw: &'a [u8]) -> Result<Self, Box<dyn StdError + Sync + Send>> {
         let id = Uuid::from_sql(ty, raw)?;
         Ok(Self(id))

--- a/models/src/id.rs
+++ b/models/src/id.rs
@@ -2,10 +2,16 @@ use postgres_types::{ToSql, Type, IsNull, to_sql_checked, FromSql};
 use std::{error::Error as StdError, fmt::{Display, Formatter, Result as FmtResult}};
 use bytes::BytesMut;
 use serde::{Deserialize, Serialize};
-use twilight_model::id::GuildId as DiscordGuildId;
+use twilight_model::id::{GuildId as DiscordGuildId, UserId as DiscordUserId, RoleId as DiscordRoleId};
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct GuildId(pub DiscordGuildId);
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct UserId(pub DiscordUserId);
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct RoleId(pub DiscordRoleId);
 
 impl GuildId {
     pub fn new(n: u64) -> Self {
@@ -17,7 +23,39 @@ impl GuildId {
     }
 }
 
+impl UserId {
+    pub fn new(n: u64) -> Self {
+        Self(DiscordUserId::new(n).unwrap())
+    }
+
+    pub const fn get(self) -> u64 {
+        self.0.get()
+    }
+}
+
+impl RoleId {
+    pub fn new(n: u64) -> Self {
+        Self(DiscordRoleId::new(n).unwrap())
+    }
+
+    pub const fn get(self) -> u64 {
+        self.0.get()
+    }
+}
+
 impl Display for GuildId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        Display::fmt(&self.0, f)
+    }
+}
+
+impl Display for UserId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        Display::fmt(&self.0, f)
+    }
+}
+
+impl Display for RoleId {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         Display::fmt(&self.0, f)
     }
@@ -35,7 +73,53 @@ impl ToSql for GuildId {
     to_sql_checked!();
 }
 
+impl ToSql for UserId {
+    fn to_sql(&self, ty: &Type, out: &mut BytesMut) -> Result<IsNull, Box<dyn StdError + Sync + Send>> {
+        i64::to_sql(&(self.get() as i64), ty, out)
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        <i64 as ToSql>::accepts(ty)
+    }
+
+    to_sql_checked!();
+}
+
+impl ToSql for RoleId {
+    fn to_sql(&self, ty: &Type, out: &mut BytesMut) -> Result<IsNull, Box<dyn StdError + Sync + Send>> {
+        i64::to_sql(&(self.get() as i64), ty, out)
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        <i64 as ToSql>::accepts(ty)
+    }
+
+    to_sql_checked!();
+}
+
 impl<'a> FromSql<'a> for GuildId {
+    fn from_sql(ty: &Type, raw: &'a [u8]) -> Result<Self, Box<dyn StdError + Sync + Send>> {
+        let id = i64::from_sql(ty, raw)?;
+        Ok(Self::new(id as u64))
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        <i64 as FromSql>::accepts(ty)
+    }
+}
+
+impl<'a> FromSql<'a> for UserId {
+    fn from_sql(ty: &Type, raw: &'a [u8]) -> Result<Self, Box<dyn StdError + Sync + Send>> {
+        let id = i64::from_sql(ty, raw)?;
+        Ok(Self::new(id as u64))
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        <i64 as FromSql>::accepts(ty)
+    }
+}
+
+impl<'a> FromSql<'a> for RoleId {
     fn from_sql(ty: &Type, raw: &'a [u8]) -> Result<Self, Box<dyn StdError + Sync + Send>> {
         let id = i64::from_sql(ty, raw)?;
         Ok(Self::new(id as u64))

--- a/models/src/lib.rs
+++ b/models/src/lib.rs
@@ -8,6 +8,7 @@
     clippy::cast_sign_loss
 )]
 
+use serde::Serializer;
 use tokio_postgres::Row;
 
 pub use twilight_model as discord;
@@ -31,5 +32,20 @@ pub trait FromRow {
 impl FromRow for Row {
     fn from_row(row: Row) -> Result<Self, tokio_postgres::Error> {
         Ok(row)
+    }
+}
+
+pub(crate) fn serialize_i64_as_string<S: Serializer>(x: &i64, serializer: S) -> Result<S::Ok, S::Error> {
+    serializer.serialize_str(&x.to_string())
+}
+
+pub(crate) fn serialize_vec_as_string<S: Serializer>(x: &Vec<i64>, serializer: S) -> Result<S::Ok, S::Error> {
+    serializer.collect_seq(x.iter().map(|n| n.to_string()).collect::<Vec<_>>())
+}
+
+pub(crate) fn serialize_option_as_string<S: Serializer, T: ToString>(x: &Option<T>, serializer: S) -> Result<S::Ok, S::Error> {
+    match x {
+        Some(x) => serializer.serialize_some(&x.to_string()),
+        None => serializer.serialize_none()
     }
 }

--- a/models/src/lib.rs
+++ b/models/src/lib.rs
@@ -43,10 +43,3 @@ pub(crate) fn serialize_i64_as_string<S: Serializer>(x: &i64, serializer: S) -> 
 pub(crate) fn serialize_vec_as_string<S: Serializer>(x: &Vec<i64>, serializer: S) -> Result<S::Ok, S::Error> {
     serializer.collect_seq(x.iter().map(|n| n.to_string()).collect::<Vec<_>>())
 }
-
-pub(crate) fn serialize_option_as_string<S: Serializer, T: ToString>(x: &Option<T>, serializer: S) -> Result<S::Ok, S::Error> {
-    match x {
-        Some(x) => serializer.serialize_some(&x.to_string()),
-        None => serializer.serialize_none()
-    }
-}

--- a/models/src/lib.rs
+++ b/models/src/lib.rs
@@ -18,6 +18,7 @@ pub mod bind;
 pub mod blacklist;
 pub mod events;
 pub mod guild;
+pub mod id;
 pub mod roblox;
 pub mod rolang;
 pub mod stats;

--- a/models/src/lib.rs
+++ b/models/src/lib.rs
@@ -36,10 +36,16 @@ impl FromRow for Row {
     }
 }
 
-pub(crate) fn serialize_i64_as_string<S: Serializer>(x: &i64, serializer: S) -> Result<S::Ok, S::Error> {
+pub(crate) fn serialize_i64_as_string<S: Serializer>(
+    x: &i64,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
     serializer.serialize_str(&x.to_string())
 }
 
-pub(crate) fn serialize_vec_as_string<S: Serializer>(x: &Vec<i64>, serializer: S) -> Result<S::Ok, S::Error> {
+pub(crate) fn serialize_vec_as_string<S: Serializer>(
+    x: &Vec<i64>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
     serializer.collect_seq(x.iter().map(|n| n.to_string()).collect::<Vec<_>>())
 }

--- a/models/src/rolang/expression.rs
+++ b/models/src/rolang/expression.rs
@@ -1,4 +1,4 @@
-use twilight_model::id::RoleId;
+use crate::id::RoleId;
 
 use super::{
     parser::ParseError,
@@ -58,7 +58,7 @@ impl Expression {
                 }
                 TokenType::HasRole => {
                     if let Literal::Number(num) = &args[0] {
-                        let id = RoleId::new(*num as u64).unwrap();
+                        let id = RoleId::new(*num as u64);
                         let success = user.roles.contains(&id);
                         return Ok(Literal::Bool(success));
                     }

--- a/models/src/rolang/mod.rs
+++ b/models/src/rolang/mod.rs
@@ -3,7 +3,7 @@ mod parser;
 mod scanner;
 mod token;
 
-use crate::{user::RoGuildUser, id::RoleId};
+use crate::{id::RoleId, user::RoGuildUser};
 
 use std::{
     collections::HashMap,

--- a/models/src/rolang/mod.rs
+++ b/models/src/rolang/mod.rs
@@ -3,13 +3,12 @@ mod parser;
 mod scanner;
 mod token;
 
-use crate::user::RoGuildUser;
+use crate::{user::RoGuildUser, id::RoleId};
 
 use std::{
     collections::HashMap,
     fmt::{Display, Formatter, Result as FmtResult},
 };
-use twilight_model::id::RoleId;
 
 use expression::Expression;
 use parser::Parser;

--- a/models/src/user/mod.rs
+++ b/models/src/user/mod.rs
@@ -2,7 +2,7 @@ mod flags;
 
 use serde::{Deserialize, Serialize};
 
-use crate::FromRow;
+use crate::{FromRow, id::GuildId};
 
 pub use flags::UserFlags;
 
@@ -13,14 +13,14 @@ pub struct RoUser {
     pub alts: Vec<i64>,
     pub flags: UserFlags,
     pub patreon_id: Option<i64>,
-    pub premium_servers: Vec<i64>,
+    pub premium_servers: Vec<GuildId>,
     pub transferred_from: Option<i64>,
     pub transferred_to: Option<i64>,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct RoGuildUser {
-    pub guild_id: i64,
+    pub guild_id: GuildId,
     pub discord_id: i64,
     pub roblox_id: i64,
 }

--- a/models/src/user/mod.rs
+++ b/models/src/user/mod.rs
@@ -2,7 +2,10 @@ mod flags;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{FromRow, id::{GuildId, UserId}};
+use crate::{
+    id::{GuildId, UserId},
+    FromRow,
+};
 
 pub use flags::UserFlags;
 

--- a/models/src/user/mod.rs
+++ b/models/src/user/mod.rs
@@ -2,33 +2,33 @@ mod flags;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{FromRow, id::GuildId};
+use crate::{FromRow, id::{GuildId, UserId}};
 
 pub use flags::UserFlags;
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct RoUser {
-    pub discord_id: i64,
+    pub discord_id: UserId,
     pub default_roblox_id: i64,
     pub alts: Vec<i64>,
     pub flags: UserFlags,
     pub patreon_id: Option<i64>,
     pub premium_servers: Vec<GuildId>,
-    pub transferred_from: Option<i64>,
-    pub transferred_to: Option<i64>,
+    pub transferred_from: Option<UserId>,
+    pub transferred_to: Option<UserId>,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct RoGuildUser {
     pub guild_id: GuildId,
-    pub discord_id: i64,
+    pub discord_id: UserId,
     pub roblox_id: i64,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct QueueUser {
     pub roblox_id: i64,
-    pub discord_id: i64,
+    pub discord_id: UserId,
     pub verified: bool,
 }
 

--- a/rowifi/src/commands/analytics/mod.rs
+++ b/rowifi/src/commands/analytics/mod.rs
@@ -48,11 +48,7 @@ pub fn analytics_config(cmds: &mut Vec<Command>) {
 }
 
 pub async fn analytics_config_view(ctx: CommandContext) -> CommandResult {
-    let guild = ctx
-        .bot
-        .database
-        .get_guild(ctx.guild_id.unwrap())
-        .await?;
+    let guild = ctx.bot.database.get_guild(ctx.guild_id.unwrap()).await?;
 
     if guild.kind != GuildType::Beta {
         let embed = EmbedBuilder::new()

--- a/rowifi/src/commands/analytics/mod.rs
+++ b/rowifi/src/commands/analytics/mod.rs
@@ -51,7 +51,7 @@ pub async fn analytics_config_view(ctx: CommandContext) -> CommandResult {
     let guild = ctx
         .bot
         .database
-        .get_guild(ctx.guild_id.unwrap().0.get() as i64)
+        .get_guild(ctx.guild_id.unwrap())
         .await?;
 
     if guild.kind != GuildType::Beta {

--- a/rowifi/src/commands/analytics/register.rs
+++ b/rowifi/src/commands/analytics/register.rs
@@ -9,7 +9,7 @@ pub struct RegisterArguments {
 
 pub async fn analytics_register(ctx: CommandContext, args: RegisterArguments) -> CommandResult {
     let guild_id = ctx.guild_id.unwrap();
-    let guild = ctx.bot.database.get_guild(guild_id.0.get() as i64).await?;
+    let guild = ctx.bot.database.get_guild(guild_id).await?;
 
     if guild.kind != GuildType::Beta {
         let embed = EmbedBuilder::new()
@@ -55,7 +55,7 @@ pub struct UnregisterArguments {
 
 pub async fn analytics_unregister(ctx: CommandContext, args: UnregisterArguments) -> CommandResult {
     let guild_id = ctx.guild_id.unwrap();
-    let guild = ctx.bot.database.get_guild(guild_id.0.get() as i64).await?;
+    let guild = ctx.bot.database.get_guild(guild_id).await?;
 
     if guild.kind != GuildType::Beta {
         let embed = EmbedBuilder::new()

--- a/rowifi/src/commands/analytics/view.rs
+++ b/rowifi/src/commands/analytics/view.rs
@@ -20,7 +20,7 @@ pub struct ViewDuration(pub Duration);
 
 pub async fn analytics_view(ctx: CommandContext, args: ViewArguments) -> CommandResult {
     let guild_id = ctx.guild_id.unwrap();
-    let guild = ctx.bot.database.get_guild(guild_id.get() as i64).await?;
+    let guild = ctx.bot.database.get_guild(guild_id).await?;
 
     if guild.kind != GuildType::Beta {
         let embed = EmbedBuilder::new()

--- a/rowifi/src/commands/api/mod.rs
+++ b/rowifi/src/commands/api/mod.rs
@@ -89,7 +89,7 @@ pub async fn api_generate(ctx: CommandContext) -> CommandResult {
         return Ok(());
     }
 
-    let filter = doc! {"_id": guild_id.0.get() as i64};
+    let filter = doc! {"_id": guild_id};
     let update = doc! {"$set": {"APIKey": hash}};
     ctx.bot.database.modify_guild(filter, update).await?;
     Ok(())

--- a/rowifi/src/commands/assetbinds/delete.rs
+++ b/rowifi/src/commands/assetbinds/delete.rs
@@ -20,7 +20,7 @@ pub async fn assetbinds_delete(ctx: CommandContext, args: DeleteArguments) -> Co
         .database
         .query::<Assetbind>(
             "SELECT * FROM binds WHERE guild_id = $1 AND bind_type  = $2 ORDER BY asset_id",
-            &[&(guild_id.get() as i64), &BindType::Asset],
+            &[&(guild_id), &BindType::Asset],
         )
         .await?;
 
@@ -145,7 +145,7 @@ pub async fn assetbinds_delete(ctx: CommandContext, args: DeleteArguments) -> Co
                                 &statement,
                                 &[
                                     &BindType::Asset,
-                                    &(guild_id.get() as i64),
+                                    &(guild_id),
                                     &bind.asset_id,
                                     &bind.asset_type,
                                     &bind.discord_roles,

--- a/rowifi/src/commands/assetbinds/mod.rs
+++ b/rowifi/src/commands/assetbinds/mod.rs
@@ -55,7 +55,7 @@ pub async fn assetbind(ctx: CommandContext) -> CommandResult {
         .database
         .query::<Assetbind>(
             "SELECT * FROM binds WHERE guild_id = $1 AND bind_type  = $2 ORDER BY asset_id",
-            &[&(guild_id.get() as i64), &BindType::Asset],
+            &[&(guild_id), &BindType::Asset],
         )
         .await?;
 

--- a/rowifi/src/commands/assetbinds/modify.rs
+++ b/rowifi/src/commands/assetbinds/modify.rs
@@ -1,6 +1,9 @@
 use itertools::Itertools;
 use rowifi_framework::prelude::*;
-use rowifi_models::{bind::{Assetbind, BindType}, id::RoleId};
+use rowifi_models::{
+    bind::{Assetbind, BindType},
+    id::RoleId,
+};
 
 #[derive(FromArgs)]
 pub struct ModifyArguments {

--- a/rowifi/src/commands/assetbinds/modify.rs
+++ b/rowifi/src/commands/assetbinds/modify.rs
@@ -1,6 +1,6 @@
 use itertools::Itertools;
 use rowifi_framework::prelude::*;
-use rowifi_models::bind::{Assetbind, BindType};
+use rowifi_models::{bind::{Assetbind, BindType}, id::RoleId};
 
 #[derive(FromArgs)]
 pub struct ModifyArguments {
@@ -119,13 +119,13 @@ async fn add_roles(
     ctx: &CommandContext,
     bind: &Assetbind,
     roles: &str,
-) -> Result<Vec<i64>, RoError> {
+) -> Result<Vec<RoleId>, RoError> {
     let mut role_ids = Vec::new();
     for r in roles.split_ascii_whitespace() {
         if let Some(resolved) = &ctx.resolved {
-            role_ids.extend(resolved.roles.iter().map(|r| r.0.get() as i64));
+            role_ids.extend(resolved.roles.iter().map(|r| RoleId(*r.0)));
         } else if let Some(r) = parse_role(r) {
-            role_ids.push(r as i64);
+            role_ids.push(r);
         }
     }
     role_ids = role_ids.into_iter().unique().collect::<Vec<_>>();
@@ -137,13 +137,13 @@ async fn remove_roles(
     ctx: &CommandContext,
     bind: &Assetbind,
     roles: &str,
-) -> Result<Vec<i64>, RoError> {
+) -> Result<Vec<RoleId>, RoError> {
     let mut role_ids = Vec::new();
     for r in roles.split_ascii_whitespace() {
         if let Some(resolved) = &ctx.resolved {
-            role_ids.extend(resolved.roles.iter().map(|r| r.0.get() as i64));
+            role_ids.extend(resolved.roles.iter().map(|r| RoleId(*r.0)));
         } else if let Some(r) = parse_role(r) {
-            role_ids.push(r as i64);
+            role_ids.push(r);
         }
     }
     role_ids = role_ids.into_iter().unique().collect::<Vec<_>>();

--- a/rowifi/src/commands/assetbinds/modify.rs
+++ b/rowifi/src/commands/assetbinds/modify.rs
@@ -28,7 +28,7 @@ pub async fn assetbinds_modify(ctx: CommandContext, args: ModifyArguments) -> Co
         .database
         .query::<Assetbind>(
             "SELECT * FROM binds WHERE guild_id = $1 AND bind_type  = $2 ORDER BY asset_id",
-            &[&(guild_id.get() as i64), &BindType::Asset],
+            &[&(guild_id), &BindType::Asset],
         )
         .await?;
 

--- a/rowifi/src/commands/assetbinds/new.rs
+++ b/rowifi/src/commands/assetbinds/new.rs
@@ -95,7 +95,7 @@ pub async fn assetbinds_new(ctx: CommandContext, args: NewArguments) -> CommandR
         "INSERT INTO binds(bind_type, guild_id, asset_id, asset_type, discord_roles, priority, template) VALUES($1, $2, $3, $4, $5, $6, $7) RETURNING bind_id",
         &[&BindType::Asset, &(guild_id), &bind.asset_id, &bind.asset_type, &bind.discord_roles, &bind.priority, &bind.template]
     ).await?;
-    let bind_id: i64 = row.get("bind_id");
+    let bind_id: BindId = row.get("bind_id");
 
     let name = format!("Id: {}", asset_id);
     let value = format!(

--- a/rowifi/src/commands/assetbinds/new.rs
+++ b/rowifi/src/commands/assetbinds/new.rs
@@ -3,7 +3,7 @@ use rowifi_database::postgres::Row;
 use rowifi_framework::prelude::*;
 use rowifi_models::{
     bind::{AssetType, Assetbind, BindType, Template},
-    discord::id::RoleId,
+    id::RoleId,
 };
 
 #[derive(FromArgs)]
@@ -72,10 +72,10 @@ pub async fn assetbinds_new(ctx: CommandContext, args: NewArguments) -> CommandR
     let mut roles = Vec::new();
     for r in roles_to_add {
         if let Some(resolved) = &ctx.resolved {
-            roles.extend(resolved.roles.iter().map(|r| r.0.get() as i64));
+            roles.extend(resolved.roles.iter().map(|r| RoleId(*r.0)));
         } else if let Some(role_id) = parse_role(r) {
-            if server_roles.contains(&RoleId::new(role_id).unwrap()) {
-                roles.push(role_id as i64);
+            if server_roles.contains(&role_id) {
+                roles.push(role_id);
             }
         }
     }

--- a/rowifi/src/commands/assetbinds/new.rs
+++ b/rowifi/src/commands/assetbinds/new.rs
@@ -3,7 +3,7 @@ use rowifi_database::postgres::Row;
 use rowifi_framework::prelude::*;
 use rowifi_models::{
     bind::{AssetType, Assetbind, BindType, Template},
-    id::RoleId,
+    id::{BindId, RoleId},
 };
 
 #[derive(FromArgs)]
@@ -81,9 +81,9 @@ pub async fn assetbinds_new(ctx: CommandContext, args: NewArguments) -> CommandR
     }
 
     let bind = Assetbind {
-        // 0 is entered here since this field is not used in the insertion. The struct is only constructed to ensure we have
+        // default is entered here since this field is not used in the insertion. The struct is only constructed to ensure we have
         // collected all fields.
-        bind_id: 0,
+        bind_id: BindId::default(),
         asset_id,
         asset_type,
         discord_roles: roles.into_iter().unique().collect::<Vec<_>>(),

--- a/rowifi/src/commands/assetbinds/new.rs
+++ b/rowifi/src/commands/assetbinds/new.rs
@@ -27,7 +27,7 @@ pub async fn assetbinds_new(ctx: CommandContext, args: NewArguments) -> CommandR
         .database
         .query::<Assetbind>(
             "SELECT * FROM binds WHERE guild_id = $1 AND bind_type  = $2 ORDER BY asset_id",
-            &[&(guild_id.get() as i64), &BindType::Asset],
+            &[&(guild_id), &BindType::Asset],
         )
         .await?;
 
@@ -93,7 +93,7 @@ pub async fn assetbinds_new(ctx: CommandContext, args: NewArguments) -> CommandR
 
     let row = ctx.bot.database.query_one::<Row>(
         "INSERT INTO binds(bind_type, guild_id, asset_id, asset_type, discord_roles, priority, template) VALUES($1, $2, $3, $4, $5, $6, $7) RETURNING bind_id",
-        &[&BindType::Asset, &(guild_id.get() as i64), &bind.asset_id, &bind.asset_type, &bind.discord_roles, &bind.priority, &bind.template]
+        &[&BindType::Asset, &(guild_id), &bind.asset_id, &bind.asset_type, &bind.discord_roles, &bind.priority, &bind.template]
     ).await?;
     let bind_id: i64 = row.get("bind_id");
 

--- a/rowifi/src/commands/backup/new.rs
+++ b/rowifi/src/commands/backup/new.rs
@@ -3,8 +3,8 @@ use rowifi_framework::prelude::*;
 use rowifi_models::{
     bind::{AssetbindBackup, Bind, BindBackup, CustombindBackup, GroupbindBackup, RankbindBackup},
     guild::backup::{GuildBackup, GuildBackupData},
-    user::{RoUser, UserFlags},
     id::UserId,
+    user::{RoUser, UserFlags},
 };
 use std::collections::HashMap;
 
@@ -39,10 +39,7 @@ pub async fn backup_new(ctx: CommandContext, args: BackupArguments) -> CommandRe
     let binds = ctx
         .bot
         .database
-        .query::<Bind>(
-            "SELECT * FROM binds WHERE guild_id = $1",
-            &[&(guild_id)],
-        )
+        .query::<Bind>("SELECT * FROM binds WHERE guild_id = $1", &[&(guild_id)])
         .await?;
 
     let name = args.name;

--- a/rowifi/src/commands/backup/new.rs
+++ b/rowifi/src/commands/backup/new.rs
@@ -3,7 +3,7 @@ use rowifi_framework::prelude::*;
 use rowifi_models::{
     bind::{AssetbindBackup, Bind, BindBackup, CustombindBackup, GroupbindBackup, RankbindBackup},
     guild::backup::{GuildBackup, GuildBackupData},
-    id::UserId,
+    id::{UserId, BackupId},
     user::{RoUser, UserFlags},
 };
 use std::collections::HashMap;
@@ -114,7 +114,7 @@ pub async fn backup_new(ctx: CommandContext, args: BackupArguments) -> CommandRe
         .collect();
 
     let backup = GuildBackup {
-        backup_id: 0,
+        backup_id: BackupId::default(),
         discord_id: UserId(ctx.author.id),
         name: name.clone(),
         data: Json(GuildBackupData {

--- a/rowifi/src/commands/backup/new.rs
+++ b/rowifi/src/commands/backup/new.rs
@@ -4,6 +4,7 @@ use rowifi_models::{
     bind::{AssetbindBackup, Bind, BindBackup, CustombindBackup, GroupbindBackup, RankbindBackup},
     guild::backup::{GuildBackup, GuildBackupData},
     user::{RoUser, UserFlags},
+    id::UserId,
 };
 use std::collections::HashMap;
 
@@ -117,7 +118,7 @@ pub async fn backup_new(ctx: CommandContext, args: BackupArguments) -> CommandRe
 
     let backup = GuildBackup {
         backup_id: 0,
-        discord_id: ctx.author.id.get() as i64,
+        discord_id: UserId(ctx.author.id),
         name: name.clone(),
         data: Json(GuildBackupData {
             command_prefix: guild.command_prefix,

--- a/rowifi/src/commands/backup/new.rs
+++ b/rowifi/src/commands/backup/new.rs
@@ -2,7 +2,6 @@ use rowifi_database::postgres::types::Json;
 use rowifi_framework::prelude::*;
 use rowifi_models::{
     bind::{AssetbindBackup, Bind, BindBackup, CustombindBackup, GroupbindBackup, RankbindBackup},
-    discord::id::RoleId,
     guild::backup::{GuildBackup, GuildBackupData},
     user::{RoUser, UserFlags},
 };
@@ -67,12 +66,12 @@ pub async fn backup_new(ctx: CommandContext, args: BackupArguments) -> CommandRe
     let verification_roles = guild
         .verification_roles
         .iter()
-        .filter_map(|r| roles.get(&RoleId::new(*r as u64).unwrap()).cloned())
+        .filter_map(|r| roles.get(r).cloned())
         .collect();
     let verified_roles = guild
         .verified_roles
         .iter()
-        .filter_map(|r| roles.get(&RoleId::new(*r as u64).unwrap()).cloned())
+        .filter_map(|r| roles.get(r).cloned())
         .collect();
     let binds = binds
         .into_iter()
@@ -80,7 +79,7 @@ pub async fn backup_new(ctx: CommandContext, args: BackupArguments) -> CommandRe
             let discord_roles = b
                 .discord_roles()
                 .iter()
-                .filter_map(|r| roles.get(&RoleId::new(*r as u64).unwrap()).cloned())
+                .filter_map(|r| roles.get(&r).cloned())
                 .collect();
 
             match b {

--- a/rowifi/src/commands/backup/new.rs
+++ b/rowifi/src/commands/backup/new.rs
@@ -35,13 +35,13 @@ pub async fn backup_new(ctx: CommandContext, args: BackupArguments) -> CommandRe
     };
 
     let guild_id = ctx.guild_id.unwrap();
-    let guild = ctx.bot.database.get_guild(guild_id.0.get() as i64).await?;
+    let guild = ctx.bot.database.get_guild(guild_id).await?;
     let binds = ctx
         .bot
         .database
         .query::<Bind>(
             "SELECT * FROM binds WHERE guild_id = $1",
-            &[&(guild_id.get() as i64)],
+            &[&(guild_id)],
         )
         .await?;
 

--- a/rowifi/src/commands/backup/restore.rs
+++ b/rowifi/src/commands/backup/restore.rs
@@ -5,6 +5,7 @@ use rowifi_models::{
     guild::{backup::GuildBackup, GuildType, RoGuild},
     rolang::RoCommand,
     user::{RoUser, UserFlags},
+    id::RoleId,
 };
 use std::collections::HashMap;
 
@@ -97,7 +98,7 @@ pub async fn backup_restore(ctx: CommandContext, args: BackupArguments) -> Comma
                 .await?
                 .model()
                 .await?;
-            roles_map.insert(role.name, role.id);
+            roles_map.insert(role.name, RoleId(role.id));
         }
     }
 
@@ -115,12 +116,12 @@ pub async fn backup_restore(ctx: CommandContext, args: BackupArguments) -> Comma
     let verification_roles = data
         .verification_roles
         .iter()
-        .filter_map(|v| roles_map.get(v).map(|r| r.get() as i64))
+        .filter_map(|v| roles_map.get(v).cloned())
         .collect();
     let verified_roles = data
         .verified_roles
         .iter()
-        .filter_map(|v| roles_map.get(v).map(|r| r.get() as i64))
+        .filter_map(|v| roles_map.get(v).cloned())
         .collect();
 
     let binds = data
@@ -130,7 +131,7 @@ pub async fn backup_restore(ctx: CommandContext, args: BackupArguments) -> Comma
             let discord_roles = b
                 .discord_roles()
                 .iter()
-                .filter_map(|v| roles_map.get(v).map(|r| r.get() as i64))
+                .filter_map(|v| roles_map.get(v).cloned())
                 .collect();
 
             match b {

--- a/rowifi/src/commands/backup/restore.rs
+++ b/rowifi/src/commands/backup/restore.rs
@@ -3,9 +3,9 @@ use rowifi_framework::prelude::*;
 use rowifi_models::{
     bind::{Assetbind, Bind, BindBackup, BindType, Custombind, Groupbind, Rankbind},
     guild::{backup::GuildBackup, GuildType, RoGuild},
+    id::RoleId,
     rolang::RoCommand,
     user::{RoUser, UserFlags},
-    id::RoleId,
 };
 use std::collections::HashMap;
 

--- a/rowifi/src/commands/backup/restore.rs
+++ b/rowifi/src/commands/backup/restore.rs
@@ -3,7 +3,7 @@ use rowifi_framework::prelude::*;
 use rowifi_models::{
     bind::{Assetbind, Bind, BindBackup, BindType, Custombind, Groupbind, Rankbind},
     guild::{backup::GuildBackup, GuildType, RoGuild},
-    id::RoleId,
+    id::{BindId, RoleId},
     rolang::RoCommand,
     user::{RoUser, UserFlags},
 };
@@ -136,7 +136,7 @@ pub async fn backup_restore(ctx: CommandContext, args: BackupArguments) -> Comma
 
             match b {
                 BindBackup::Rank(r) => Bind::Rank(Rankbind {
-                    bind_id: 0,
+                    bind_id: BindId::default(),
                     group_id: r.group_id,
                     group_rank_id: r.group_rank_id,
                     roblox_rank_id: r.roblox_rank_id,
@@ -145,14 +145,14 @@ pub async fn backup_restore(ctx: CommandContext, args: BackupArguments) -> Comma
                     priority: r.priority,
                 }),
                 BindBackup::Group(g) => Bind::Group(Groupbind {
-                    bind_id: 0,
+                    bind_id: BindId::default(),
                     group_id: g.group_id,
                     discord_roles,
                     template: g.template,
                     priority: g.priority,
                 }),
                 BindBackup::Custom(c) => Bind::Custom(Custombind {
-                    bind_id: 0,
+                    bind_id: BindId::default(),
                     custom_bind_id: c.custom_bind_id,
                     code: c.code.clone(),
                     command: RoCommand::new(&c.code).unwrap(),
@@ -161,7 +161,7 @@ pub async fn backup_restore(ctx: CommandContext, args: BackupArguments) -> Comma
                     priority: c.priority,
                 }),
                 BindBackup::Asset(a) => Bind::Asset(Assetbind {
-                    bind_id: 0,
+                    bind_id: BindId::default(),
                     asset_id: a.asset_id,
                     asset_type: a.asset_type,
                     discord_roles,

--- a/rowifi/src/commands/backup/restore.rs
+++ b/rowifi/src/commands/backup/restore.rs
@@ -36,7 +36,7 @@ pub async fn backup_restore(ctx: CommandContext, args: BackupArguments) -> Comma
 
     let guild_id = ctx.guild_id.unwrap();
     let name = args.name;
-    ctx.bot.database.get_guild(guild_id.0.get() as i64).await?;
+    ctx.bot.database.get_guild(guild_id).await?;
 
     let backup = match ctx
         .bot
@@ -91,7 +91,7 @@ pub async fn backup_restore(ctx: CommandContext, args: BackupArguments) -> Comma
             let role = ctx
                 .bot
                 .http
-                .create_role(guild_id)
+                .create_role(guild_id.0)
                 .name(&r)
                 .exec()
                 .await?
@@ -172,7 +172,7 @@ pub async fn backup_restore(ctx: CommandContext, args: BackupArguments) -> Comma
         .collect::<Vec<_>>();
 
     let guild = RoGuild {
-        guild_id: ctx.guild_id.unwrap().get() as i64,
+        guild_id: ctx.guild_id.unwrap(),
         command_prefix: data.command_prefix,
         verification_roles,
         verified_roles,

--- a/rowifi/src/commands/blacklists/custom.rs
+++ b/rowifi/src/commands/blacklists/custom.rs
@@ -1,9 +1,9 @@
 use rowifi_framework::prelude::*;
 use rowifi_models::{
     blacklist::{Blacklist, BlacklistData},
+    id::UserId,
     roblox::id::UserId as RobloxUserId,
     rolang::{RoCommand, RoCommandUser},
-    id::UserId,
 };
 use std::collections::HashMap;
 

--- a/rowifi/src/commands/blacklists/custom.rs
+++ b/rowifi/src/commands/blacklists/custom.rs
@@ -17,7 +17,7 @@ pub async fn blacklist_custom(
     args: BlacklistCustomArguments,
 ) -> CommandResult {
     let guild_id = ctx.guild_id.unwrap();
-    let guild = ctx.bot.database.get_guild(guild_id.0.get() as i64).await?;
+    let guild = ctx.bot.database.get_guild(guild_id).await?;
 
     let code = args.code;
     if code.is_empty() {
@@ -34,7 +34,7 @@ pub async fn blacklist_custom(
     let user = match ctx
         .bot
         .database
-        .get_linked_user(ctx.author.id.get() as i64, guild_id.get() as i64)
+        .get_linked_user(ctx.author.id.get() as i64, guild_id)
         .await?
     {
         Some(u) => u,
@@ -97,7 +97,7 @@ pub async fn blacklist_custom(
         .database
         .execute(
             r#"UPDATE guilds SET blacklists = array_append(blacklists, $1) WHERE guild_id = $2"#,
-            &[&blacklist, &(guild_id.get() as i64)],
+            &[&blacklist, &(guild_id)],
         )
         .await?;
 
@@ -173,7 +173,7 @@ pub async fn blacklist_custom(
                         .exec()
                         .await?;
 
-                    ctx.bot.database.execute("UPDATE guilds SET blacklists = array_remove(blacklists, $1) WHERE guild_id = $2", &[&blacklist, &(guild_id.get() as i64)]).await?;
+                    ctx.bot.database.execute("UPDATE guilds SET blacklists = array_remove(blacklists, $1) WHERE guild_id = $2", &[&blacklist, &(guild_id)]).await?;
 
                     let embed = EmbedBuilder::new()
                         .default_data()

--- a/rowifi/src/commands/blacklists/custom.rs
+++ b/rowifi/src/commands/blacklists/custom.rs
@@ -3,6 +3,7 @@ use rowifi_models::{
     blacklist::{Blacklist, BlacklistData},
     roblox::id::UserId as RobloxUserId,
     rolang::{RoCommand, RoCommandUser},
+    id::UserId,
 };
 use std::collections::HashMap;
 
@@ -34,7 +35,7 @@ pub async fn blacklist_custom(
     let user = match ctx
         .bot
         .database
-        .get_linked_user(ctx.author.id.get() as i64, guild_id)
+        .get_linked_user(UserId(ctx.author.id), guild_id)
         .await?
     {
         Some(u) => u,
@@ -51,7 +52,7 @@ pub async fn blacklist_custom(
         }
     };
     let user_id = RobloxUserId(user.roblox_id as u64);
-    let member = ctx.member(guild_id, ctx.author.id.0).await?.unwrap();
+    let member = ctx.member(guild_id, UserId(ctx.author.id)).await?.unwrap();
     let ranks = ctx
         .bot
         .roblox

--- a/rowifi/src/commands/blacklists/delete.rs
+++ b/rowifi/src/commands/blacklists/delete.rs
@@ -11,7 +11,7 @@ pub async fn blacklist_delete(
     args: BlacklistDeleteArguments,
 ) -> CommandResult {
     let guild_id = ctx.guild_id.unwrap();
-    let guild = ctx.bot.database.get_guild(guild_id.0.get() as i64).await?;
+    let guild = ctx.bot.database.get_guild(guild_id).await?;
 
     let id = args.id;
     let blacklist = match guild.blacklists.iter().find(|b| b.blacklist_id == id) {
@@ -33,7 +33,7 @@ pub async fn blacklist_delete(
         .database
         .execute(
             "UPDATE guilds SET blacklists = array_remove(blacklists, $1) WHERE guild_id = $2",
-            &[&blacklist, &(guild_id.get() as i64)],
+            &[&blacklist, &(guild_id)],
         )
         .await?;
 
@@ -113,7 +113,7 @@ pub async fn blacklist_delete(
 
                     ctx.bot.database.execute(
                         r#"UPDATE guilds SET blacklists = array_append(blacklists, $1) WHERE guild_id = $2"#,
-                        &[&blacklist, &(guild_id.get() as i64)]
+                        &[&blacklist, &(guild_id)]
                     ).await?;
 
                     let embed = EmbedBuilder::new()

--- a/rowifi/src/commands/blacklists/group.rs
+++ b/rowifi/src/commands/blacklists/group.rs
@@ -11,7 +11,7 @@ pub struct BlacklistGroupArguments {
 
 pub async fn blacklist_group(ctx: CommandContext, args: BlacklistGroupArguments) -> CommandResult {
     let guild_id = ctx.guild_id.unwrap();
-    let guild = ctx.bot.database.get_guild(guild_id.0.get() as i64).await?;
+    let guild = ctx.bot.database.get_guild(guild_id).await?;
 
     let group_id = args.group_id;
     let mut reason = args.reason;
@@ -35,7 +35,7 @@ pub async fn blacklist_group(ctx: CommandContext, args: BlacklistGroupArguments)
         .database
         .execute(
             r#"UPDATE guilds SET blacklists = array_append(blacklists, $1) WHERE guild_id = $2"#,
-            &[&blacklist, &(guild_id.get() as i64)],
+            &[&blacklist, &(guild_id)],
         )
         .await?;
 
@@ -111,7 +111,7 @@ pub async fn blacklist_group(ctx: CommandContext, args: BlacklistGroupArguments)
                         .exec()
                         .await?;
 
-                    ctx.bot.database.execute("UPDATE guilds SET blacklists = array_remove(blacklists, $1) WHERE guild_id = $2", &[&blacklist, &(guild_id.get() as i64)]).await?;
+                    ctx.bot.database.execute("UPDATE guilds SET blacklists = array_remove(blacklists, $1) WHERE guild_id = $2", &[&blacklist, &(guild_id)]).await?;
 
                     let embed = EmbedBuilder::new()
                         .default_data()

--- a/rowifi/src/commands/blacklists/mod.rs
+++ b/rowifi/src/commands/blacklists/mod.rs
@@ -59,7 +59,7 @@ pub fn blacklists_config(cmds: &mut Vec<Command>) {
 
 pub async fn blacklist(ctx: CommandContext) -> CommandResult {
     let guild_id = ctx.guild_id.unwrap();
-    let guild = ctx.bot.database.get_guild(guild_id.0.get() as i64).await?;
+    let guild = ctx.bot.database.get_guild(guild_id).await?;
 
     if guild.blacklists.is_empty() {
         let e = EmbedBuilder::new()

--- a/rowifi/src/commands/blacklists/name.rs
+++ b/rowifi/src/commands/blacklists/name.rs
@@ -11,7 +11,7 @@ pub struct BlacklistNameArguments {
 
 pub async fn blacklist_name(ctx: CommandContext, args: BlacklistNameArguments) -> CommandResult {
     let guild_id = ctx.guild_id.unwrap();
-    let guild = ctx.bot.database.get_guild(guild_id.0.get() as i64).await?;
+    let guild = ctx.bot.database.get_guild(guild_id).await?;
 
     let username = args.username;
     let user = match ctx.bot.roblox.get_user_from_username(&username).await? {
@@ -54,7 +54,7 @@ pub async fn blacklist_name(ctx: CommandContext, args: BlacklistNameArguments) -
         .database
         .execute(
             r#"UPDATE guilds SET blacklists = array_append(blacklists, $1) WHERE guild_id = $2"#,
-            &[&blacklist, &(guild_id.get() as i64)],
+            &[&blacklist, &(guild_id)],
         )
         .await?;
 
@@ -130,7 +130,7 @@ pub async fn blacklist_name(ctx: CommandContext, args: BlacklistNameArguments) -
                         .exec()
                         .await?;
 
-                    ctx.bot.database.execute("UPDATE guilds SET blacklists = array_remove(blacklists, $1) WHERE guild_id = $2", &[&blacklist, &(guild_id.get() as i64)]).await?;
+                    ctx.bot.database.execute("UPDATE guilds SET blacklists = array_remove(blacklists, $1) WHERE guild_id = $2", &[&blacklist, &(guild_id)]).await?;
 
                     let embed = EmbedBuilder::new()
                         .default_data()

--- a/rowifi/src/commands/custombinds/delete.rs
+++ b/rowifi/src/commands/custombinds/delete.rs
@@ -18,7 +18,7 @@ pub async fn custombinds_delete(
         .database
         .query::<Custombind>(
             "SELECT * FROM binds WHERE guild_id = $1 AND bind_type  = $2 ORDER BY custom_bind_id",
-            &[&(guild_id.get() as i64), &BindType::Custom],
+            &[&(guild_id), &BindType::Custom],
         )
         .await?;
 
@@ -146,7 +146,7 @@ pub async fn custombinds_delete(
                                 &statement,
                                 &[
                                     &BindType::Custom,
-                                    &(guild_id.get() as i64),
+                                    &(guild_id),
                                     &bind.discord_roles,
                                     &bind.code,
                                     &bind.priority,

--- a/rowifi/src/commands/custombinds/mod.rs
+++ b/rowifi/src/commands/custombinds/mod.rs
@@ -56,7 +56,7 @@ pub async fn custombinds_view(ctx: CommandContext) -> CommandResult {
         .database
         .query::<Custombind>(
             "SELECT * FROM binds WHERE guild_id = $1 AND bind_type  = $2 ORDER BY custom_bind_id",
-            &[&(guild_id.get() as i64), &BindType::Custom],
+            &[&(guild_id), &BindType::Custom],
         )
         .await?;
 

--- a/rowifi/src/commands/custombinds/modify.rs
+++ b/rowifi/src/commands/custombinds/modify.rs
@@ -2,7 +2,7 @@ use itertools::Itertools;
 use rowifi_framework::prelude::*;
 use rowifi_models::{
     bind::{BindType, Custombind},
-    discord::id::GuildId,
+    id::GuildId,
     roblox::id::UserId as RobloxUserId,
     rolang::{RoCommand, RoCommandUser},
 };
@@ -38,7 +38,7 @@ pub async fn custombinds_modify(
         .database
         .query::<Custombind>(
             "SELECT * FROM binds WHERE guild_id = $1 AND bind_type  = $2 ORDER BY custom_bind_id",
-            &[&(guild_id.get() as i64), &BindType::Custom],
+            &[&(guild_id), &BindType::Custom],
         )
         .await?;
 
@@ -138,7 +138,7 @@ async fn modify_code<'a>(
     let user = match ctx
         .bot
         .database
-        .get_linked_user(ctx.author.id.get() as i64, guild_id.get() as i64)
+        .get_linked_user(ctx.author.id.get() as i64, guild_id)
         .await?
     {
         Some(u) => u,

--- a/rowifi/src/commands/custombinds/modify.rs
+++ b/rowifi/src/commands/custombinds/modify.rs
@@ -2,7 +2,7 @@ use itertools::Itertools;
 use rowifi_framework::prelude::*;
 use rowifi_models::{
     bind::{BindType, Custombind},
-    id::GuildId,
+    id::{GuildId, RoleId},
     roblox::id::UserId as RobloxUserId,
     rolang::{RoCommand, RoCommandUser},
 };
@@ -247,13 +247,13 @@ async fn add_roles(
     ctx: &CommandContext,
     bind: &Custombind,
     roles: &str,
-) -> Result<Vec<i64>, RoError> {
+) -> Result<Vec<RoleId>, RoError> {
     let mut role_ids = Vec::new();
     for r in roles.split_ascii_whitespace() {
         if let Some(resolved) = &ctx.resolved {
-            role_ids.extend(resolved.roles.iter().map(|r| r.0.get() as i64));
+            role_ids.extend(resolved.roles.iter().map(|r| RoleId(*r.0)));
         } else if let Some(r) = parse_role(r) {
-            role_ids.push(r as i64);
+            role_ids.push(r);
         }
     }
     role_ids = role_ids.into_iter().unique().collect::<Vec<_>>();
@@ -265,13 +265,13 @@ async fn remove_roles(
     ctx: &CommandContext,
     bind: &Custombind,
     roles: &str,
-) -> Result<Vec<i64>, RoError> {
+) -> Result<Vec<RoleId>, RoError> {
     let mut role_ids = Vec::new();
     for r in roles.split_ascii_whitespace() {
         if let Some(resolved) = &ctx.resolved {
-            role_ids.extend(resolved.roles.iter().map(|r| r.0.get() as i64));
+            role_ids.extend(resolved.roles.iter().map(|r| RoleId(*r.0)));
         } else if let Some(r) = parse_role(r) {
-            role_ids.push(r as i64);
+            role_ids.push(r);
         }
     }
     role_ids = role_ids.into_iter().unique().collect::<Vec<_>>();

--- a/rowifi/src/commands/custombinds/modify.rs
+++ b/rowifi/src/commands/custombinds/modify.rs
@@ -2,7 +2,7 @@ use itertools::Itertools;
 use rowifi_framework::prelude::*;
 use rowifi_models::{
     bind::{BindType, Custombind},
-    id::{GuildId, RoleId},
+    id::{GuildId, RoleId, UserId},
     roblox::id::UserId as RobloxUserId,
     rolang::{RoCommand, RoCommandUser},
 };
@@ -138,7 +138,7 @@ async fn modify_code<'a>(
     let user = match ctx
         .bot
         .database
-        .get_linked_user(ctx.author.id.get() as i64, guild_id)
+        .get_linked_user(UserId(ctx.author.id), guild_id)
         .await?
     {
         Some(u) => u,
@@ -157,7 +157,7 @@ async fn modify_code<'a>(
 
     let user_id = RobloxUserId(user.roblox_id as u64);
     let member = ctx
-        .member(ctx.guild_id.unwrap(), ctx.author.id.0)
+        .member(ctx.guild_id.unwrap(), UserId(ctx.author.id))
         .await?
         .unwrap();
     let ranks = ctx

--- a/rowifi/src/commands/custombinds/new.rs
+++ b/rowifi/src/commands/custombinds/new.rs
@@ -3,7 +3,7 @@ use rowifi_database::postgres::Row;
 use rowifi_framework::prelude::*;
 use rowifi_models::{
     bind::{BindType, Custombind, Template},
-    id::{GuildId, RoleId, UserId},
+    id::{BindId, GuildId, RoleId, UserId},
     roblox::id::UserId as RobloxUserId,
     rolang::{RoCommand, RoCommandUser},
 };
@@ -285,9 +285,9 @@ pub async fn custombinds_new_common(
     }
 
     let bind = Custombind {
-        // 0 is used here since this field is not used in inserting the bind. The struct is only created for thr purpose
+        // default is entered here since this field is not used in inserting the bind. The struct is only created for thr purpose
         // of ensuring all fields are collected.
-        bind_id: 0,
+        bind_id: BindId::default(),
         custom_bind_id: 0,
         code: args.code.clone(),
         priority,

--- a/rowifi/src/commands/custombinds/new.rs
+++ b/rowifi/src/commands/custombinds/new.rs
@@ -3,8 +3,7 @@ use rowifi_database::postgres::Row;
 use rowifi_framework::prelude::*;
 use rowifi_models::{
     bind::{BindType, Custombind, Template},
-    id::{GuildId},
-    discord::id::RoleId,
+    id::{GuildId, RoleId},
     roblox::id::UserId as RobloxUserId,
     rolang::{RoCommand, RoCommandUser},
 };
@@ -277,10 +276,10 @@ pub async fn custombinds_new_common(
     let mut roles = Vec::new();
     for role_str in discord_roles_str.split_ascii_whitespace() {
         if let Some(resolved) = &ctx.resolved {
-            roles.extend(resolved.roles.iter().map(|r| r.0.get() as i64));
+            roles.extend(resolved.roles.iter().map(|r| RoleId(*r.0)));
         } else if let Some(role_id) = parse_role(role_str) {
-            if server_roles.contains(&RoleId::new(role_id).unwrap()) {
-                roles.push(role_id as i64);
+            if server_roles.contains(&role_id) {
+                roles.push(role_id);
             }
         }
     }

--- a/rowifi/src/commands/custombinds/new.rs
+++ b/rowifi/src/commands/custombinds/new.rs
@@ -302,7 +302,7 @@ pub async fn custombinds_new_common(
         RETURNING custom_bind_id, bind_id"#,
      &[&BindType::Custom, &(guild_id), &bind.discord_roles, &bind.code, &bind.priority, &bind.template]
     ).await?;
-    let bind_id: i64 = row.get("bind_id");
+    let bind_id: BindId = row.get("bind_id");
 
     let name = format!("Id: {}", row.get::<'_, _, i32>("custom_bind_id"));
     let roles_str = bind

--- a/rowifi/src/commands/custombinds/new.rs
+++ b/rowifi/src/commands/custombinds/new.rs
@@ -3,7 +3,8 @@ use rowifi_database::postgres::Row;
 use rowifi_framework::prelude::*;
 use rowifi_models::{
     bind::{BindType, Custombind, Template},
-    discord::id::{GuildId, RoleId},
+    id::{GuildId},
+    discord::id::RoleId,
     roblox::id::UserId as RobloxUserId,
     rolang::{RoCommand, RoCommandUser},
 };
@@ -140,7 +141,7 @@ pub async fn custombinds_new_common(
     let user = match ctx
         .bot
         .database
-        .get_linked_user(ctx.author.id.get() as i64, guild_id.get() as i64)
+        .get_linked_user(ctx.author.id.get() as i64, guild_id)
         .await?
     {
         Some(u) => u,
@@ -300,7 +301,7 @@ pub async fn custombinds_new_common(
         INSERT INTO binds(bind_type, guild_id, custom_bind_id, discord_roles, code, priority, template) 
         VALUES($1, $2, (SELECT COALESCE(max(custom_bind_id) + 1, 1) FROM binds WHERE guild_id = $2 AND bind_type = $1), $3, $4, $5, $6)
         RETURNING custom_bind_id, bind_id"#,
-     &[&BindType::Custom, &(guild_id.get() as i64), &bind.discord_roles, &bind.code, &bind.priority, &bind.template]
+     &[&BindType::Custom, &(guild_id), &bind.discord_roles, &bind.code, &bind.priority, &bind.template]
     ).await?;
     let bind_id: i64 = row.get("bind_id");
 

--- a/rowifi/src/commands/custombinds/new.rs
+++ b/rowifi/src/commands/custombinds/new.rs
@@ -3,7 +3,7 @@ use rowifi_database::postgres::Row;
 use rowifi_framework::prelude::*;
 use rowifi_models::{
     bind::{BindType, Custombind, Template},
-    id::{GuildId, RoleId},
+    id::{GuildId, RoleId, UserId},
     roblox::id::UserId as RobloxUserId,
     rolang::{RoCommand, RoCommandUser},
 };
@@ -140,7 +140,7 @@ pub async fn custombinds_new_common(
     let user = match ctx
         .bot
         .database
-        .get_linked_user(ctx.author.id.get() as i64, guild_id)
+        .get_linked_user(UserId(ctx.author.id), guild_id)
         .await?
     {
         Some(u) => u,
@@ -158,7 +158,7 @@ pub async fn custombinds_new_common(
     };
     let user_id = RobloxUserId(user.roblox_id as u64);
     let member = ctx
-        .member(ctx.guild_id.unwrap(), ctx.author.id.0)
+        .member(ctx.guild_id.unwrap(), UserId(ctx.author.id))
         .await?
         .unwrap();
     let ranks = ctx

--- a/rowifi/src/commands/events/mod.rs
+++ b/rowifi/src/commands/events/mod.rs
@@ -109,7 +109,7 @@ pub fn events_config(cmds: &mut Vec<Command>) {
 
 pub async fn events(ctx: CommandContext) -> CommandResult {
     let guild_id = ctx.guild_id.unwrap();
-    let guild = ctx.bot.database.get_guild(guild_id.0.get() as i64).await?;
+    let guild = ctx.bot.database.get_guild(guild_id).await?;
 
     if guild.kind != GuildType::Beta {
         let embed = EmbedBuilder::new()

--- a/rowifi/src/commands/events/new.rs
+++ b/rowifi/src/commands/events/new.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 pub async fn events_new(ctx: CommandContext) -> CommandResult {
     let guild_id = ctx.guild_id.unwrap();
-    let guild = ctx.bot.database.get_guild(guild_id.0.get() as i64).await?;
+    let guild = ctx.bot.database.get_guild(guild_id).await?;
 
     if guild.kind != GuildType::Beta {
         let embed = EmbedBuilder::new()
@@ -25,7 +25,7 @@ pub async fn events_new(ctx: CommandContext) -> CommandResult {
     let roblox_id = match ctx
         .bot
         .database
-        .get_linked_user(ctx.author.id.get() as i64, guild_id.get() as i64)
+        .get_linked_user(ctx.author.id.get() as i64, guild_id)
         .await?
     {
         Some(r) => r.roblox_id,
@@ -47,7 +47,7 @@ pub async fn events_new(ctx: CommandContext) -> CommandResult {
         .database
         .query::<EventType>(
             "SELECT * FROM event_types WHERE guild_id = $1",
-            &[&(guild_id.get() as i64)],
+            &[&(guild_id)],
         )
         .await?;
 
@@ -230,7 +230,7 @@ pub async fn events_new(ctx: CommandContext) -> CommandResult {
 
     let new_event = EventLog {
         event_id: 0,
-        guild_id: guild_id.get() as i64,
+        guild_id: guild_id,
         event_type: event_type.event_type_guild_id,
         guild_event_id: 0,
         host_id: roblox_id,

--- a/rowifi/src/commands/events/new.rs
+++ b/rowifi/src/commands/events/new.rs
@@ -3,6 +3,7 @@ use rowifi_framework::prelude::*;
 use rowifi_models::{
     events::{EventLog, EventType},
     guild::GuildType,
+    id::UserId,
 };
 use std::time::Duration;
 
@@ -25,7 +26,7 @@ pub async fn events_new(ctx: CommandContext) -> CommandResult {
     let roblox_id = match ctx
         .bot
         .database
-        .get_linked_user(ctx.author.id.get() as i64, guild_id)
+        .get_linked_user(UserId(ctx.author.id), guild_id)
         .await?
     {
         Some(r) => r.roblox_id,

--- a/rowifi/src/commands/events/new.rs
+++ b/rowifi/src/commands/events/new.rs
@@ -3,7 +3,7 @@ use rowifi_framework::prelude::*;
 use rowifi_models::{
     events::{EventLog, EventType},
     guild::GuildType,
-    id::UserId,
+    id::{UserId, EventId},
 };
 use std::time::Duration;
 
@@ -230,7 +230,7 @@ pub async fn events_new(ctx: CommandContext) -> CommandResult {
     };
 
     let new_event = EventLog {
-        event_id: 0,
+        event_id: EventId::default(),
         guild_id,
         event_type: event_type.event_type_guild_id,
         guild_event_id: 0,

--- a/rowifi/src/commands/events/new.rs
+++ b/rowifi/src/commands/events/new.rs
@@ -231,7 +231,7 @@ pub async fn events_new(ctx: CommandContext) -> CommandResult {
 
     let new_event = EventLog {
         event_id: 0,
-        guild_id: guild_id,
+        guild_id,
         event_type: event_type.event_type_guild_id,
         guild_event_id: 0,
         host_id: roblox_id,

--- a/rowifi/src/commands/events/reset.rs
+++ b/rowifi/src/commands/events/reset.rs
@@ -46,9 +46,7 @@ pub async fn event_reset(ctx: CommandContext) -> CommandResult {
     let events_change = transaction
         .prepare_cached("DELETE FROM events WHERE guild_id = $1")
         .await?;
-    transaction
-        .execute(&events_change, &[&(guild_id)])
-        .await?;
+    transaction.execute(&events_change, &[&(guild_id)]).await?;
 
     transaction.commit().await?;
 

--- a/rowifi/src/commands/events/reset.rs
+++ b/rowifi/src/commands/events/reset.rs
@@ -3,7 +3,7 @@ use rowifi_models::guild::GuildType;
 
 pub async fn event_reset(ctx: CommandContext) -> CommandResult {
     let guild_id = ctx.guild_id.unwrap();
-    let guild = ctx.bot.database.get_guild(guild_id.0.get() as i64).await?;
+    let guild = ctx.bot.database.get_guild(guild_id).await?;
 
     if guild.kind != GuildType::Beta {
         let embed = EmbedBuilder::new()
@@ -40,14 +40,14 @@ pub async fn event_reset(ctx: CommandContext) -> CommandResult {
         .prepare_cached("DELETE FROM event_types WHERE guild_id = $1")
         .await?;
     transaction
-        .execute(&event_types_change, &[&(guild_id.get() as i64)])
+        .execute(&event_types_change, &[&(guild_id)])
         .await?;
 
     let events_change = transaction
         .prepare_cached("DELETE FROM events WHERE guild_id = $1")
         .await?;
     transaction
-        .execute(&events_change, &[&(guild_id.get() as i64)])
+        .execute(&events_change, &[&(guild_id)])
         .await?;
 
     transaction.commit().await?;

--- a/rowifi/src/commands/events/summary.rs
+++ b/rowifi/src/commands/events/summary.rs
@@ -8,7 +8,7 @@ use rowifi_models::{
 
 pub async fn event_summary(ctx: CommandContext) -> CommandResult {
     let guild_id = ctx.guild_id.unwrap();
-    let guild = ctx.bot.database.get_guild(guild_id.0.get() as i64).await?;
+    let guild = ctx.bot.database.get_guild(guild_id).await?;
 
     if guild.kind != GuildType::Beta {
         let embed = EmbedBuilder::new()
@@ -27,7 +27,7 @@ pub async fn event_summary(ctx: CommandContext) -> CommandResult {
         .database
         .query::<EventType>(
             "SELECT * FROM event_types WHERE guild_id = $1",
-            &[&(guild_id.get() as i64)],
+            &[&(guild_id)],
         )
         .await?;
     let events = ctx
@@ -35,7 +35,7 @@ pub async fn event_summary(ctx: CommandContext) -> CommandResult {
         .database
         .query::<EventLog>(
             "SELECT * FROM events WHERE guild_id = $1",
-            &[&(guild_id.get() as i64)],
+            &[&(guild_id)],
         )
         .await?;
 

--- a/rowifi/src/commands/events/summary.rs
+++ b/rowifi/src/commands/events/summary.rs
@@ -33,10 +33,7 @@ pub async fn event_summary(ctx: CommandContext) -> CommandResult {
     let events = ctx
         .bot
         .database
-        .query::<EventLog>(
-            "SELECT * FROM events WHERE guild_id = $1",
-            &[&(guild_id)],
-        )
+        .query::<EventLog>("SELECT * FROM events WHERE guild_id = $1", &[&(guild_id)])
         .await?;
 
     let mut embed = EmbedBuilder::new().default_data().title("Events Summary");

--- a/rowifi/src/commands/events/types.rs
+++ b/rowifi/src/commands/events/types.rs
@@ -1,5 +1,5 @@
 use rowifi_framework::prelude::*;
-use rowifi_models::{events::EventType, guild::GuildType};
+use rowifi_models::{events::EventType, guild::GuildType, id::EventTypeId};
 
 pub async fn event_type(ctx: CommandContext) -> CommandResult {
     let guild_id = ctx.guild_id.unwrap();
@@ -85,7 +85,7 @@ pub async fn event_type_new(ctx: CommandContext, args: EventTypeArguments) -> Co
     }
 
     let event_type = EventType {
-        event_type_id: 0,
+        event_type_id: EventTypeId::default(),
         event_type_guild_id: event_id,
         guild_id,
         name: event_name.to_string(),
@@ -163,7 +163,7 @@ pub async fn event_type_modify(ctx: CommandContext, args: EventTypeArguments) ->
         )
         .await?;
 
-    let name = format!("Event Type Id: {}", event.event_type_id);
+    let name = format!("Event Type Id: {}", event.event_type_guild_id);
     let desc = format!("Name: {} -> {}", &event.name, event_name);
     let embed = EmbedBuilder::new()
         .default_data()

--- a/rowifi/src/commands/events/types.rs
+++ b/rowifi/src/commands/events/types.rs
@@ -3,7 +3,7 @@ use rowifi_models::{events::EventType, guild::GuildType};
 
 pub async fn event_type(ctx: CommandContext) -> CommandResult {
     let guild_id = ctx.guild_id.unwrap();
-    let guild = ctx.bot.database.get_guild(guild_id.0.get() as i64).await?;
+    let guild = ctx.bot.database.get_guild(guild_id).await?;
 
     if guild.kind != GuildType::Beta {
         let embed = EmbedBuilder::new()
@@ -22,7 +22,7 @@ pub async fn event_type(ctx: CommandContext) -> CommandResult {
         .database
         .query::<EventType>(
             "SELECT * FROM event_types WHERE guild_id = $1",
-            &[&(guild_id.get() as i64)],
+            &[&(guild_id)],
         )
         .await?;
 
@@ -46,7 +46,7 @@ pub struct EventTypeArguments {
 
 pub async fn event_type_new(ctx: CommandContext, args: EventTypeArguments) -> CommandResult {
     let guild_id = ctx.guild_id.unwrap();
-    let guild = ctx.bot.database.get_guild(guild_id.0.get() as i64).await?;
+    let guild = ctx.bot.database.get_guild(guild_id).await?;
 
     if guild.kind != GuildType::Beta {
         let embed = EmbedBuilder::new()
@@ -68,7 +68,7 @@ pub async fn event_type_new(ctx: CommandContext, args: EventTypeArguments) -> Co
         .database
         .query::<EventType>(
             "SELECT * FROM event_types WHERE guild_id = $1",
-            &[&(guild_id.get() as i64)],
+            &[&(guild_id)],
         )
         .await?;
 
@@ -87,7 +87,7 @@ pub async fn event_type_new(ctx: CommandContext, args: EventTypeArguments) -> Co
     let event_type = EventType {
         event_type_id: 0,
         event_type_guild_id: event_id,
-        guild_id: guild_id.get() as i64,
+        guild_id: guild_id,
         name: event_name.to_string(),
         disabled: false,
     };
@@ -110,7 +110,7 @@ pub async fn event_type_new(ctx: CommandContext, args: EventTypeArguments) -> Co
 
 pub async fn event_type_modify(ctx: CommandContext, args: EventTypeArguments) -> CommandResult {
     let guild_id = ctx.guild_id.unwrap();
-    let guild = ctx.bot.database.get_guild(guild_id.0.get() as i64).await?;
+    let guild = ctx.bot.database.get_guild(guild_id).await?;
 
     if guild.kind != GuildType::Beta {
         let embed = EmbedBuilder::new()
@@ -132,7 +132,7 @@ pub async fn event_type_modify(ctx: CommandContext, args: EventTypeArguments) ->
         .database
         .query::<EventType>(
             "SELECT * FROM event_types WHERE guild_id = $1",
-            &[&(guild_id.get() as i64)],
+            &[&(guild_id)],
         )
         .await?;
     let event = match event_types
@@ -184,7 +184,7 @@ pub struct DisableArguments {
 
 pub async fn event_type_disable(ctx: CommandContext, args: DisableArguments) -> CommandResult {
     let guild_id = ctx.guild_id.unwrap();
-    let guild = ctx.bot.database.get_guild(guild_id.0.get() as i64).await?;
+    let guild = ctx.bot.database.get_guild(guild_id).await?;
 
     if guild.kind != GuildType::Beta {
         let embed = EmbedBuilder::new()
@@ -203,7 +203,7 @@ pub async fn event_type_disable(ctx: CommandContext, args: DisableArguments) -> 
         .database
         .query::<EventType>(
             "SELECT * FROM event_types WHERE guild_id = $1",
-            &[&(guild_id.get() as i64)],
+            &[&(guild_id)],
         )
         .await?;
 
@@ -258,7 +258,7 @@ pub struct EnableArguments {
 
 pub async fn event_type_enable(ctx: CommandContext, args: EnableArguments) -> CommandResult {
     let guild_id = ctx.guild_id.unwrap();
-    let guild = ctx.bot.database.get_guild(guild_id.0.get() as i64).await?;
+    let guild = ctx.bot.database.get_guild(guild_id).await?;
 
     if guild.kind != GuildType::Beta {
         let embed = EmbedBuilder::new()
@@ -277,7 +277,7 @@ pub async fn event_type_enable(ctx: CommandContext, args: EnableArguments) -> Co
         .database
         .query::<EventType>(
             "SELECT * FROM event_types WHERE guild_id = $1",
-            &[&(guild_id.get() as i64)],
+            &[&(guild_id)],
         )
         .await?;
 

--- a/rowifi/src/commands/events/types.rs
+++ b/rowifi/src/commands/events/types.rs
@@ -87,7 +87,7 @@ pub async fn event_type_new(ctx: CommandContext, args: EventTypeArguments) -> Co
     let event_type = EventType {
         event_type_id: 0,
         event_type_guild_id: event_id,
-        guild_id: guild_id,
+        guild_id,
         name: event_name.to_string(),
         disabled: false,
     };

--- a/rowifi/src/commands/events/view.rs
+++ b/rowifi/src/commands/events/view.rs
@@ -16,7 +16,7 @@ pub struct EventAttendeeArguments {
 
 pub async fn event_attendee(ctx: CommandContext, args: EventAttendeeArguments) -> CommandResult {
     let guild_id = ctx.guild_id.unwrap();
-    let guild = ctx.bot.database.get_guild(guild_id.0.get() as i64).await?;
+    let guild = ctx.bot.database.get_guild(guild_id).await?;
 
     if guild.kind != GuildType::Beta {
         let embed = EmbedBuilder::new()
@@ -49,7 +49,7 @@ pub async fn event_attendee(ctx: CommandContext, args: EventAttendeeArguments) -
             let user = ctx
                 .bot
                 .database
-                .get_linked_user(ctx.author.id.get() as i64, guild_id.get() as i64)
+                .get_linked_user(ctx.author.id.get() as i64, guild_id)
                 .await?;
             match user {
                 Some(u) => u.roblox_id,
@@ -72,7 +72,7 @@ pub async fn event_attendee(ctx: CommandContext, args: EventAttendeeArguments) -
         .database
         .query::<EventType>(
             "SELECT * FROM event_types WHERE guild_id = $1",
-            &[&(guild_id.get() as i64)],
+            &[&(guild_id)],
         )
         .await?;
     let events = ctx
@@ -80,7 +80,7 @@ pub async fn event_attendee(ctx: CommandContext, args: EventAttendeeArguments) -
         .database
         .query::<EventLog>(
             "SELECT * FROM events WHERE guild_id = $1 AND $2 = ANY(attendees)",
-            &[&(guild_id.get() as i64), &roblox_id],
+            &[&(guild_id), &roblox_id],
         )
         .await?;
 
@@ -130,7 +130,7 @@ pub struct EventHostArguments {
 
 pub async fn event_host(ctx: CommandContext, args: EventHostArguments) -> CommandResult {
     let guild_id = ctx.guild_id.unwrap();
-    let guild = ctx.bot.database.get_guild(guild_id.0.get() as i64).await?;
+    let guild = ctx.bot.database.get_guild(guild_id).await?;
 
     if guild.kind != GuildType::Beta {
         let embed = EmbedBuilder::new()
@@ -163,7 +163,7 @@ pub async fn event_host(ctx: CommandContext, args: EventHostArguments) -> Comman
             let user = ctx
                 .bot
                 .database
-                .get_linked_user(ctx.author.id.get() as i64, guild_id.get() as i64)
+                .get_linked_user(ctx.author.id.get() as i64, guild_id)
                 .await?;
             match user {
                 Some(u) => u.roblox_id,
@@ -187,7 +187,7 @@ pub async fn event_host(ctx: CommandContext, args: EventHostArguments) -> Comman
         .database
         .query::<EventType>(
             "SELECT * FROM event_types WHERE guild_id = $1",
-            &[&(guild_id.get() as i64)],
+            &[&(guild_id)],
         )
         .await?;
     let events = ctx
@@ -195,7 +195,7 @@ pub async fn event_host(ctx: CommandContext, args: EventHostArguments) -> Comman
         .database
         .query::<EventLog>(
             "SELECT * FROM events WHERE guild_id = $1 AND host_id = $2",
-            &[&(guild_id.get() as i64), &roblox_id],
+            &[&(guild_id), &roblox_id],
         )
         .await?;
 
@@ -245,7 +245,7 @@ pub struct EventViewArguments {
 
 pub async fn event_view(ctx: CommandContext, args: EventViewArguments) -> CommandResult {
     let guild_id = ctx.guild_id.unwrap();
-    let guild = ctx.bot.database.get_guild(guild_id.0.get() as i64).await?;
+    let guild = ctx.bot.database.get_guild(guild_id).await?;
 
     if guild.kind != GuildType::Beta {
         let embed = EmbedBuilder::new()
@@ -265,7 +265,7 @@ pub async fn event_view(ctx: CommandContext, args: EventViewArguments) -> Comman
         .database
         .query::<EventType>(
             "SELECT * FROM event_types WHERE guild_id = $1",
-            &[&(guild_id.get() as i64)],
+            &[&(guild_id)],
         )
         .await?;
     let event = ctx
@@ -273,7 +273,7 @@ pub async fn event_view(ctx: CommandContext, args: EventViewArguments) -> Comman
         .database
         .query_opt::<EventLog>(
             "SELECT * FROM events WHERE guild_id = $1 AND guild_event_id = $2",
-            &[&(guild_id.get() as i64), &event_id],
+            &[&(guild_id), &event_id],
         )
         .await?;
 

--- a/rowifi/src/commands/events/view.rs
+++ b/rowifi/src/commands/events/view.rs
@@ -6,6 +6,7 @@ use rowifi_models::{
     events::{EventLog, EventType},
     guild::GuildType,
     roblox::id::UserId as RobloxUserId,
+    id::UserId
 };
 
 #[derive(FromArgs)]
@@ -49,7 +50,7 @@ pub async fn event_attendee(ctx: CommandContext, args: EventAttendeeArguments) -
             let user = ctx
                 .bot
                 .database
-                .get_linked_user(ctx.author.id.get() as i64, guild_id)
+                .get_linked_user(UserId(ctx.author.id), guild_id)
                 .await?;
             match user {
                 Some(u) => u.roblox_id,
@@ -163,7 +164,7 @@ pub async fn event_host(ctx: CommandContext, args: EventHostArguments) -> Comman
             let user = ctx
                 .bot
                 .database
-                .get_linked_user(ctx.author.id.get() as i64, guild_id)
+                .get_linked_user(UserId(ctx.author.id), guild_id)
                 .await?;
             match user {
                 Some(u) => u.roblox_id,

--- a/rowifi/src/commands/events/view.rs
+++ b/rowifi/src/commands/events/view.rs
@@ -5,8 +5,8 @@ use rowifi_models::{
     discord::datetime::Timestamp,
     events::{EventLog, EventType},
     guild::GuildType,
+    id::UserId,
     roblox::id::UserId as RobloxUserId,
-    id::UserId
 };
 
 #[derive(FromArgs)]

--- a/rowifi/src/commands/group/bind.rs
+++ b/rowifi/src/commands/group/bind.rs
@@ -4,7 +4,7 @@ use regex::Regex;
 use rowifi_framework::prelude::*;
 use rowifi_models::{
     bind::{AssetType, Assetbind, BindType, Groupbind, Rankbind, Template},
-    id::{GuildId, RoleId},
+    id::{BindId, GuildId, RoleId},
     roblox::{group::PartialRank, id::GroupId},
 };
 use std::str::FromStr;
@@ -371,9 +371,9 @@ async fn bind_asset(ctx: CommandContext, guild_id: GuildId) -> CommandResult {
     }
 
     let bind = Assetbind {
-        // 0 is entered here since this field is not used in the insertion. The struct is only constructed to ensure we have
+        // default is entered here since this field is not used in the insertion. The struct is only constructed to ensure we have
         // collected all fields.
-        bind_id: 0,
+        bind_id: BindId::default(),
         asset_id,
         asset_type,
         discord_roles: discord_roles.into_iter().unique().collect::<Vec<_>>(),
@@ -603,9 +603,9 @@ async fn bind_group(ctx: CommandContext, guild_id: GuildId) -> CommandResult {
     }
 
     let bind = Groupbind {
-        // 0 is entered here since this field is not used in the insertion. The struct is only constructed to ensure we have
+        // default is entered here since this field is not used in the insertion. The struct is only constructed to ensure we have
         // collected all fields.
-        bind_id: 0,
+        bind_id: BindId::default(),
         group_id,
         discord_roles: discord_roles.into_iter().unique().collect::<Vec<_>>(),
         priority,
@@ -684,7 +684,7 @@ async fn bind_rank(
 
         let rank_id = i64::from(group_rank.rank);
         let bind = Rankbind {
-            bind_id: 0,
+            bind_id: BindId::default(),
             group_id,
             group_rank_id: rank_id,
             roblox_rank_id: group_rank.id.0 as i64,

--- a/rowifi/src/commands/group/bind.rs
+++ b/rowifi/src/commands/group/bind.rs
@@ -4,7 +4,8 @@ use regex::Regex;
 use rowifi_framework::prelude::*;
 use rowifi_models::{
     bind::{AssetType, Assetbind, BindType, Groupbind, Rankbind, Template},
-    discord::id::{GuildId, RoleId},
+    discord::id::{RoleId},
+    id::GuildId,
     roblox::{group::PartialRank, id::GroupId},
 };
 use std::str::FromStr;
@@ -383,7 +384,7 @@ async fn bind_asset(ctx: CommandContext, guild_id: GuildId) -> CommandResult {
 
     ctx.bot.database.execute(
         "INSERT INTO binds(bind_type, guild_id, asset_id, asset_type, discord_roles, priority, template) VALUES($1, $2, $3, $4, $5, $6, $7) RETURNING bind_id",
-        &[&BindType::Asset, &(guild_id.get() as i64), &bind.asset_id, &bind.asset_type, &bind.discord_roles, &bind.priority, &bind.template]
+        &[&BindType::Asset, &(guild_id), &bind.asset_id, &bind.asset_type, &bind.discord_roles, &bind.priority, &bind.template]
     ).await?;
 
     let name = format!("Id: {}", asset_id);
@@ -614,7 +615,7 @@ async fn bind_group(ctx: CommandContext, guild_id: GuildId) -> CommandResult {
 
     ctx.bot.database.execute(
         "INSERT INTO binds(bind_type, guild_id, group_id, discord_roles, priority, template) VALUES($1, $2, $3, $4, $5, $6) RETURNING bind_id", 
-        &[&BindType::Group, &(guild_id.get() as i64), &bind.group_id, &bind.discord_roles, &bind.priority, &bind.template]
+        &[&BindType::Group, &(guild_id), &bind.group_id, &bind.discord_roles, &bind.priority, &bind.template]
     ).await?;
 
     let name = format!("Group: {}", group_id);
@@ -664,7 +665,7 @@ async fn bind_rank(
         .database
         .query::<Rankbind>(
             "SELECT * FROM binds WHERE guild_id = $1 AND bind_type = $2",
-            &[&(guild_id.0.get() as i64), &BindType::Rank],
+            &[&(guild_id), &BindType::Rank],
         )
         .await?;
 
@@ -719,7 +720,7 @@ async fn bind_rank(
                         &stmt,
                         &[
                             &BindType::Rank,
-                            &(guild_id.get() as i64),
+                            &(guild_id),
                             &bind.group_id,
                             &bind.group_rank_id,
                             &bind.roblox_rank_id,

--- a/rowifi/src/commands/group/bind.rs
+++ b/rowifi/src/commands/group/bind.rs
@@ -4,8 +4,7 @@ use regex::Regex;
 use rowifi_framework::prelude::*;
 use rowifi_models::{
     bind::{AssetType, Assetbind, BindType, Groupbind, Rankbind, Template},
-    discord::id::{RoleId},
-    id::GuildId,
+    id::{GuildId, RoleId},
     roblox::{group::PartialRank, id::GroupId},
 };
 use std::str::FromStr;
@@ -365,8 +364,8 @@ async fn bind_asset(ctx: CommandContext, guild_id: GuildId) -> CommandResult {
     let mut discord_roles = Vec::new();
     for role_str in discord_roles_str.split_ascii_whitespace() {
         if let Some(role_id) = parse_role(role_str) {
-            if server_roles.contains(&RoleId::new(role_id).unwrap()) {
-                discord_roles.push(role_id as i64);
+            if server_roles.contains(&role_id) {
+                discord_roles.push(role_id);
             }
         }
     }
@@ -581,8 +580,8 @@ async fn bind_group(ctx: CommandContext, guild_id: GuildId) -> CommandResult {
     let mut discord_roles = Vec::new();
     for role_str in discord_roles_str.split_ascii_whitespace() {
         if let Some(role_id) = parse_role(role_str) {
-            if server_roles.contains(&RoleId::new(role_id).unwrap()) {
-                discord_roles.push(role_id as i64);
+            if server_roles.contains(&role_id) {
+                discord_roles.push(role_id);
             }
         }
     }
@@ -656,7 +655,7 @@ async fn bind_rank(
     rank_ids: Vec<&PartialRank>,
     template: Template,
     priority: i32,
-    discord_roles: Vec<i64>,
+    discord_roles: Vec<RoleId>,
 ) -> CommandResult {
     let mut added = Vec::new();
     let mut modified = Vec::new();

--- a/rowifi/src/commands/group/reset.rs
+++ b/rowifi/src/commands/group/reset.rs
@@ -44,9 +44,7 @@ pub async fn reset(ctx: CommandContext) -> CommandResult {
     let delete_binds = transaction
         .prepare_cached("DELETE FROM binds WHERE guild_id = $1")
         .await?;
-    transaction
-        .execute(&delete_binds, &[&(guild_id)])
-        .await?;
+    transaction.execute(&delete_binds, &[&(guild_id)]).await?;
     transaction.commit().await?;
 
     ctx.bot.admin_roles.remove(&guild_id);

--- a/rowifi/src/commands/group/reset.rs
+++ b/rowifi/src/commands/group/reset.rs
@@ -26,15 +26,15 @@ pub async fn reset(ctx: CommandContext) -> CommandResult {
         .prepare_cached("DELETE FROM guilds WHERE guild_id = $1")
         .await?;
     transaction
-        .execute(&delete_statement, &[&(guild_id.get() as i64)])
+        .execute(&delete_statement, &[&(guild_id)])
         .await?;
     let insert_statement = transaction.prepare_cached("INSERT INTO guilds(guild_id, command_prefix, kind, blacklist_action) VALUES($1, $2, $3, $4)").await?;
-    let guild = RoGuild::new(guild_id.get() as i64);
+    let guild = RoGuild::new(guild_id);
     transaction
         .execute(
             &insert_statement,
             &[
-                &(guild_id.get() as i64),
+                &(guild_id),
                 &guild.command_prefix,
                 &guild.kind,
                 &guild.blacklist_action,
@@ -45,7 +45,7 @@ pub async fn reset(ctx: CommandContext) -> CommandResult {
         .prepare_cached("DELETE FROM binds WHERE guild_id = $1")
         .await?;
     transaction
-        .execute(&delete_binds, &[&(guild_id.get() as i64)])
+        .execute(&delete_binds, &[&(guild_id)])
         .await?;
     transaction.commit().await?;
 

--- a/rowifi/src/commands/group/serverinfo.rs
+++ b/rowifi/src/commands/group/serverinfo.rs
@@ -18,13 +18,13 @@ impl FromRow for BindCount {
 
 pub async fn serverinfo(ctx: CommandContext) -> CommandResult {
     let guild_id = ctx.guild_id.unwrap();
-    let guild = ctx.bot.database.get_guild(guild_id.0.get() as i64).await?;
+    let guild = ctx.bot.database.get_guild(guild_id).await?;
     let rows = ctx
         .bot
         .database
         .query::<BindCount>(
             "SELECT bind_type, COUNT(*) AS count FROM binds WHERE guild_id = $1 GROUP BY bind_type",
-            &[&(guild_id.get() as i64)],
+            &[&(guild_id)],
         )
         .await?;
 

--- a/rowifi/src/commands/group/update_mul.rs
+++ b/rowifi/src/commands/group/update_mul.rs
@@ -3,8 +3,9 @@ use rowifi_database::dynamic_args_with_start;
 use rowifi_framework::prelude::*;
 use rowifi_models::{
     bind::Bind,
-    discord::{gateway::payload::outgoing::RequestGuildMembers, id::RoleId},
+    discord::{gateway::payload::outgoing::RequestGuildMembers},
     guild::GuildType,
+    id::RoleId,
     roblox::id::UserId as RobloxUserId,
 };
 use std::{env, sync::atomic::Ordering};

--- a/rowifi/src/commands/group/update_mul.rs
+++ b/rowifi/src/commands/group/update_mul.rs
@@ -156,7 +156,7 @@ pub async fn update_all(ctx: CommandContext) -> CommandResult {
         let _ = c
             .bot
             .http
-            .create_message(channel_id)
+            .create_message(channel_id.0)
             .content("Finished updating all members")
             .unwrap()
             .exec()
@@ -323,7 +323,7 @@ pub async fn update_role(ctx: CommandContext, args: UpdateMultipleArguments) -> 
         let _ = c
             .bot
             .http
-            .create_message(channel_id)
+            .create_message(channel_id.0)
             .content("Finished updating all members")
             .unwrap()
             .exec()

--- a/rowifi/src/commands/group/update_mul.rs
+++ b/rowifi/src/commands/group/update_mul.rs
@@ -2,11 +2,8 @@ use itertools::Itertools;
 use rowifi_database::dynamic_args_with_start;
 use rowifi_framework::prelude::*;
 use rowifi_models::{
-    bind::Bind,
-    discord::{gateway::payload::outgoing::RequestGuildMembers},
-    guild::GuildType,
-    id::RoleId,
-    roblox::id::UserId as RobloxUserId,
+    bind::Bind, discord::gateway::payload::outgoing::RequestGuildMembers, guild::GuildType,
+    id::RoleId, roblox::id::UserId as RobloxUserId,
 };
 use std::{env, sync::atomic::Ordering};
 use tokio::time::sleep;
@@ -106,10 +103,7 @@ pub async fn update_all(ctx: CommandContext) -> CommandResult {
     let binds = ctx
         .bot
         .database
-        .query::<Bind>(
-            "SELECT * FROM binds WHERE guild_id = $1",
-            &[&(guild_id)],
-        )
+        .query::<Bind>("SELECT * FROM binds WHERE guild_id = $1", &[&(guild_id)])
         .await?;
 
     let guild_roles = ctx.bot.cache.roles(guild_id);
@@ -274,10 +268,7 @@ pub async fn update_role(ctx: CommandContext, args: UpdateMultipleArguments) -> 
     let binds = ctx
         .bot
         .database
-        .query::<Bind>(
-            "SELECT * FROM binds WHERE guild_id = $1",
-            &[&(guild_id)],
-        )
+        .query::<Bind>("SELECT * FROM binds WHERE guild_id = $1", &[&(guild_id)])
         .await?;
     let guild_roles = ctx.bot.cache.roles(guild_id);
     let c = ctx.clone();

--- a/rowifi/src/commands/groupbinds/delete.rs
+++ b/rowifi/src/commands/groupbinds/delete.rs
@@ -18,7 +18,7 @@ pub async fn groupbinds_delete(
         .database
         .query::<Groupbind>(
             "SELECT * FROM binds WHERE guild_id = $1 AND bind_type  = $2",
-            &[&(guild_id.get() as i64), &BindType::Group],
+            &[&(guild_id), &BindType::Group],
         )
         .await?;
 
@@ -143,7 +143,7 @@ pub async fn groupbinds_delete(
                                 &statement,
                                 &[
                                     &BindType::Group,
-                                    &(guild_id.get() as i64),
+                                    &(guild_id),
                                     &bind.group_id,
                                     &bind.discord_roles,
                                     &bind.priority,

--- a/rowifi/src/commands/groupbinds/mod.rs
+++ b/rowifi/src/commands/groupbinds/mod.rs
@@ -55,7 +55,7 @@ pub async fn groupbinds_view(ctx: CommandContext) -> CommandResult {
         .database
         .query::<Groupbind>(
             "SELECT * FROM binds WHERE guild_id = $1 AND bind_type  = $2 ORDER BY group_id",
-            &[&(guild_id.get() as i64), &BindType::Group],
+            &[&(guild_id), &BindType::Group],
         )
         .await?;
 

--- a/rowifi/src/commands/groupbinds/modify.rs
+++ b/rowifi/src/commands/groupbinds/modify.rs
@@ -1,6 +1,9 @@
 use itertools::Itertools;
 use rowifi_framework::prelude::*;
-use rowifi_models::{bind::{BindType, Groupbind}, id::RoleId};
+use rowifi_models::{
+    bind::{BindType, Groupbind},
+    id::RoleId,
+};
 
 #[derive(FromArgs)]
 pub struct GroupbindsModifyArguments {

--- a/rowifi/src/commands/groupbinds/modify.rs
+++ b/rowifi/src/commands/groupbinds/modify.rs
@@ -31,7 +31,7 @@ pub async fn groupbinds_modify(
         .database
         .query::<Groupbind>(
             "SELECT * FROM binds WHERE guild_id = $1 AND bind_type  = $2 ORDER BY group_id",
-            &[&(guild_id.get() as i64), &BindType::Group],
+            &[&(guild_id), &BindType::Group],
         )
         .await?;
 

--- a/rowifi/src/commands/groupbinds/modify.rs
+++ b/rowifi/src/commands/groupbinds/modify.rs
@@ -1,6 +1,6 @@
 use itertools::Itertools;
 use rowifi_framework::prelude::*;
-use rowifi_models::bind::{BindType, Groupbind};
+use rowifi_models::{bind::{BindType, Groupbind}, id::RoleId};
 
 #[derive(FromArgs)]
 pub struct GroupbindsModifyArguments {
@@ -118,13 +118,13 @@ async fn add_roles(
     ctx: &CommandContext,
     bind: &Groupbind,
     roles: &str,
-) -> Result<Vec<i64>, RoError> {
+) -> Result<Vec<RoleId>, RoError> {
     let mut role_ids = Vec::new();
     for r in roles.split_ascii_whitespace() {
         if let Some(resolved) = &ctx.resolved {
-            role_ids.extend(resolved.roles.iter().map(|r| r.0.get() as i64));
+            role_ids.extend(resolved.roles.iter().map(|r| RoleId(*r.0)));
         } else if let Some(r) = parse_role(r) {
-            role_ids.push(r as i64);
+            role_ids.push(r);
         }
     }
     role_ids = role_ids.into_iter().unique().collect::<Vec<_>>();
@@ -136,13 +136,13 @@ async fn remove_roles(
     ctx: &CommandContext,
     bind: &Groupbind,
     roles: &str,
-) -> Result<Vec<i64>, RoError> {
+) -> Result<Vec<RoleId>, RoError> {
     let mut role_ids = Vec::new();
     for r in roles.split_ascii_whitespace() {
         if let Some(resolved) = &ctx.resolved {
-            role_ids.extend(resolved.roles.iter().map(|r| r.0.get() as i64));
+            role_ids.extend(resolved.roles.iter().map(|r| RoleId(*r.0)));
         } else if let Some(r) = parse_role(r) {
-            role_ids.push(r as i64);
+            role_ids.push(r);
         }
     }
     role_ids = role_ids.into_iter().unique().collect::<Vec<_>>();

--- a/rowifi/src/commands/groupbinds/new.rs
+++ b/rowifi/src/commands/groupbinds/new.rs
@@ -3,7 +3,7 @@ use rowifi_database::postgres::Row;
 use rowifi_framework::prelude::*;
 use rowifi_models::{
     bind::{BindType, Groupbind, Template},
-    discord::id::RoleId,
+    id::RoleId,
 };
 
 #[derive(FromArgs)]
@@ -66,10 +66,10 @@ pub async fn groupbinds_new(ctx: CommandContext, args: GroupbindsNewArguments) -
     let mut roles = Vec::new();
     for r in roles_to_add {
         if let Some(resolved) = &ctx.resolved {
-            roles.extend(resolved.roles.iter().map(|r| r.0.get() as i64));
+            roles.extend(resolved.roles.iter().map(|r| RoleId(*r.0)));
         } else if let Some(role_id) = parse_role(r) {
-            if server_roles.contains(&RoleId::new(role_id).unwrap()) {
-                roles.push(role_id as i64);
+            if server_roles.contains(&role_id) {
+                roles.push(role_id);
             }
         }
     }

--- a/rowifi/src/commands/groupbinds/new.rs
+++ b/rowifi/src/commands/groupbinds/new.rs
@@ -25,7 +25,7 @@ pub async fn groupbinds_new(ctx: CommandContext, args: GroupbindsNewArguments) -
         .database
         .query::<Groupbind>(
             "SELECT * FROM binds WHERE guild_id = $1 AND bind_type  = $2 ORDER BY group_id",
-            &[&(guild_id.get() as i64), &BindType::Group],
+            &[&(guild_id), &BindType::Group],
         )
         .await?;
 
@@ -86,7 +86,7 @@ pub async fn groupbinds_new(ctx: CommandContext, args: GroupbindsNewArguments) -
 
     let row = ctx.bot.database.query_one::<Row>(
         "INSERT INTO binds(bind_type, guild_id, group_id, discord_roles, priority, template) VALUES($1, $2, $3, $4, $5, $6) RETURNING bind_id", 
-        &[&BindType::Group, &(guild_id.get() as i64), &bind.group_id, &bind.discord_roles, &bind.priority, &bind.template]
+        &[&BindType::Group, &(guild_id), &bind.group_id, &bind.discord_roles, &bind.priority, &bind.template]
     ).await?;
     let bind_id: i64 = row.get("bind_id");
 

--- a/rowifi/src/commands/groupbinds/new.rs
+++ b/rowifi/src/commands/groupbinds/new.rs
@@ -3,7 +3,7 @@ use rowifi_database::postgres::Row;
 use rowifi_framework::prelude::*;
 use rowifi_models::{
     bind::{BindType, Groupbind, Template},
-    id::RoleId,
+    id::{BindId, RoleId},
 };
 
 #[derive(FromArgs)]
@@ -75,9 +75,9 @@ pub async fn groupbinds_new(ctx: CommandContext, args: GroupbindsNewArguments) -
     }
 
     let bind = Groupbind {
-        // 0 is entered here since this field is not used in the insertion. The struct is only constructed to ensure we have
+        // default is entered here since this field is not used in the insertion. The struct is only constructed to ensure we have
         // collected all fields.
-        bind_id: 0,
+        bind_id: BindId::default(),
         group_id,
         discord_roles: roles.into_iter().unique().collect::<Vec<_>>(),
         priority,

--- a/rowifi/src/commands/premium/mod.rs
+++ b/rowifi/src/commands/premium/mod.rs
@@ -4,7 +4,7 @@ mod transfer;
 
 use rowifi_framework::prelude::*;
 use rowifi_models::{
-    discord::id::UserId,
+    id::UserId,
     user::{RoUser, UserFlags},
 };
 

--- a/rowifi/src/commands/premium/redeem.rs
+++ b/rowifi/src/commands/premium/redeem.rs
@@ -64,7 +64,7 @@ pub async fn premium_redeem(ctx: CommandContext) -> CommandResult {
         }
     }
 
-    let guild = ctx.bot.database.get_guild(guild_id.0.get() as i64).await?;
+    let guild = ctx.bot.database.get_guild(guild_id).await?;
 
     let mut db = ctx.bot.database.get().await?;
     let transaction = db.transaction().await?;
@@ -88,13 +88,13 @@ pub async fn premium_redeem(ctx: CommandContext) -> CommandResult {
 
     if !premium_user
         .premium_servers
-        .contains(&(guild_id.0.get() as i64))
+        .contains(&(guild_id))
     {
         let user_change = transaction.prepare_cached("UPDATE users SET premium_servers = array_append(premium_servers, $1) WHERE discord_id = $2").await?;
         transaction
             .execute(
                 &user_change,
-                &[&(guild_id.get() as i64), &(ctx.author.id.get() as i64)],
+                &[&(guild_id), &(ctx.author.id.get() as i64)],
             )
             .await?;
     }
@@ -142,7 +142,7 @@ pub async fn premium_redeem(ctx: CommandContext) -> CommandResult {
         .unwrap();
     ctx.respond().embeds(&[embed])?.exec().await?;
 
-    let req = RequestGuildMembers::builder(server.id).query("", None);
+    let req = RequestGuildMembers::builder(server.id.0).query("", None);
     let total_shards = env::var("TOTAL_SHARDS").unwrap().parse::<u64>().unwrap();
     let shard_id = (guild_id.0.get() >> 22) % total_shards;
     let _res = ctx.bot.cluster.command(shard_id, &req).await;
@@ -173,7 +173,7 @@ pub async fn premium_remove(ctx: CommandContext) -> CommandResult {
 
     if !premium_user
         .premium_servers
-        .contains(&(guild_id.0.get() as i64))
+        .contains(&(guild_id))
     {
         let embed = EmbedBuilder::new().default_data().color(Color::Red as u32)
             .title("Premium Disable Failed")
@@ -183,7 +183,7 @@ pub async fn premium_remove(ctx: CommandContext) -> CommandResult {
         return Ok(());
     }
 
-    let guild = ctx.bot.database.get_guild(guild_id.0.get() as i64).await?;
+    let guild = ctx.bot.database.get_guild(guild_id).await?;
 
     let mut db = ctx.bot.database.get().await?;
     let transaction = db.transaction().await?;

--- a/rowifi/src/commands/premium/redeem.rs
+++ b/rowifi/src/commands/premium/redeem.rs
@@ -1,6 +1,6 @@
 use rowifi_framework::prelude::*;
 use rowifi_models::{
-    discord::{gateway::payload::outgoing::RequestGuildMembers, id::RoleId},
+    discord::gateway::payload::outgoing::RequestGuildMembers,
     guild::GuildType,
     user::{RoUser, UserFlags},
 };
@@ -104,33 +104,25 @@ pub async fn premium_redeem(ctx: CommandContext) -> CommandResult {
         guild_id,
         guild
             .admin_roles
-            .iter()
-            .map(|r| RoleId::new(*r as u64).unwrap())
-            .collect(),
+            .clone(),
     );
     ctx.bot.trainer_roles.insert(
         guild_id,
         guild
             .trainer_roles
-            .iter()
-            .map(|r| RoleId::new(*r as u64).unwrap())
-            .collect(),
+            .clone(),
     );
     ctx.bot.bypass_roles.insert(
         guild_id,
         guild
             .bypass_roles
-            .iter()
-            .map(|r| RoleId::new(*r as u64).unwrap())
-            .collect(),
+            .clone(),
     );
     ctx.bot.nickname_bypass_roles.insert(
         guild_id,
         guild
             .nickname_bypass_roles
-            .iter()
-            .map(|r| RoleId::new(*r as u64).unwrap())
-            .collect(),
+            .clone(),
     );
 
     let embed = EmbedBuilder::new()

--- a/rowifi/src/commands/premium/redeem.rs
+++ b/rowifi/src/commands/premium/redeem.rs
@@ -2,8 +2,8 @@ use rowifi_framework::prelude::*;
 use rowifi_models::{
     discord::gateway::payload::outgoing::RequestGuildMembers,
     guild::GuildType,
+    id::UserId,
     user::{RoUser, UserFlags},
-    id::UserId
 };
 use std::env;
 
@@ -88,44 +88,26 @@ pub async fn premium_redeem(ctx: CommandContext) -> CommandResult {
         )
         .await?;
 
-    if !premium_user
-        .premium_servers
-        .contains(&(guild_id))
-    {
+    if !premium_user.premium_servers.contains(&(guild_id)) {
         let user_change = transaction.prepare_cached("UPDATE users SET premium_servers = array_append(premium_servers, $1) WHERE discord_id = $2").await?;
         transaction
-            .execute(
-                &user_change,
-                &[&(guild_id), &(ctx.author.id.get() as i64)],
-            )
+            .execute(&user_change, &[&(guild_id), &(ctx.author.id.get() as i64)])
             .await?;
     }
     transaction.commit().await?;
 
-    ctx.bot.admin_roles.insert(
-        guild_id,
-        guild
-            .admin_roles
-            .clone(),
-    );
-    ctx.bot.trainer_roles.insert(
-        guild_id,
-        guild
-            .trainer_roles
-            .clone(),
-    );
-    ctx.bot.bypass_roles.insert(
-        guild_id,
-        guild
-            .bypass_roles
-            .clone(),
-    );
-    ctx.bot.nickname_bypass_roles.insert(
-        guild_id,
-        guild
-            .nickname_bypass_roles
-            .clone(),
-    );
+    ctx.bot
+        .admin_roles
+        .insert(guild_id, guild.admin_roles.clone());
+    ctx.bot
+        .trainer_roles
+        .insert(guild_id, guild.trainer_roles.clone());
+    ctx.bot
+        .bypass_roles
+        .insert(guild_id, guild.bypass_roles.clone());
+    ctx.bot
+        .nickname_bypass_roles
+        .insert(guild_id, guild.nickname_bypass_roles.clone());
 
     let embed = EmbedBuilder::new()
         .default_data()
@@ -165,10 +147,7 @@ pub async fn premium_remove(ctx: CommandContext) -> CommandResult {
         }
     };
 
-    if !premium_user
-        .premium_servers
-        .contains(&(guild_id))
-    {
+    if !premium_user.premium_servers.contains(&(guild_id)) {
         let embed = EmbedBuilder::new().default_data().color(Color::Red as u32)
             .title("Premium Disable Failed")
             .description("This server either does not have premium enabled or the premium is owned by an another member")

--- a/rowifi/src/commands/premium/redeem.rs
+++ b/rowifi/src/commands/premium/redeem.rs
@@ -3,6 +3,7 @@ use rowifi_models::{
     discord::gateway::payload::outgoing::RequestGuildMembers,
     guild::GuildType,
     user::{RoUser, UserFlags},
+    id::UserId
 };
 use std::env;
 
@@ -38,7 +39,8 @@ pub async fn premium_redeem(ctx: CommandContext) -> CommandResult {
     }
 
     let server = ctx.bot.cache.guild(guild_id).unwrap();
-    if !(server.owner_id == ctx.author.id || ctx.bot.owners.contains(&ctx.author.id)) {
+    let author_id = UserId(ctx.author.id);
+    if !(server.owner_id == author_id || ctx.bot.owners.contains(&author_id)) {
         let embed = EmbedBuilder::new()
             .default_data()
             .color(Color::Red as u32)

--- a/rowifi/src/commands/premium/transfer.rs
+++ b/rowifi/src/commands/premium/transfer.rs
@@ -1,6 +1,6 @@
 use rowifi_framework::prelude::*;
 use rowifi_models::{
-    discord::id::UserId,
+    id::UserId,
     guild::GuildType,
     user::{RoUser, UserFlags},
 };
@@ -77,7 +77,7 @@ pub async fn premium_transfer(
         }
     };
 
-    if to_transfer_id == ctx.author.id {
+    if to_transfer_id.0 == ctx.author.id {
         let embed = EmbedBuilder::new()
             .default_data()
             .color(Color::Red as u32)

--- a/rowifi/src/commands/premium/transfer.rs
+++ b/rowifi/src/commands/premium/transfer.rs
@@ -1,7 +1,7 @@
 use rowifi_framework::prelude::*;
 use rowifi_models::{
-    id::UserId,
     guild::GuildType,
+    id::UserId,
     user::{RoUser, UserFlags},
 };
 

--- a/rowifi/src/commands/rankbinds/delete.rs
+++ b/rowifi/src/commands/rankbinds/delete.rs
@@ -19,7 +19,7 @@ pub async fn rankbinds_delete(ctx: CommandContext, args: RankBindsDelete) -> Com
         .database
         .query::<Rankbind>(
             "SELECT * FROM binds WHERE guild_id = $1 AND bind_type = $2",
-            &[&(guild_id.get() as i64), &BindType::Rank],
+            &[&(guild_id), &BindType::Rank],
         )
         .await?;
 
@@ -160,7 +160,7 @@ pub async fn rankbinds_delete(ctx: CommandContext, args: RankBindsDelete) -> Com
                                 &stmt,
                                 &[
                                     &BindType::Rank,
-                                    &(guild_id.get() as i64),
+                                    &(guild_id),
                                     &bind.group_id,
                                     &bind.group_rank_id,
                                     &bind.roblox_rank_id,

--- a/rowifi/src/commands/rankbinds/mod.rs
+++ b/rowifi/src/commands/rankbinds/mod.rs
@@ -56,7 +56,7 @@ pub async fn rankbinds_view(ctx: CommandContext) -> Result<(), RoError> {
         .database
         .query::<Rankbind>(
             "SELECT * FROM binds WHERE guild_id = $1 AND bind_type = $2 ORDER BY group_id ASC, group_rank_id ASC",
-            &[&(guild_id.get() as i64), &BindType::Rank],
+            &[&(guild_id), &BindType::Rank],
         )
         .await?;
 

--- a/rowifi/src/commands/rankbinds/modify.rs
+++ b/rowifi/src/commands/rankbinds/modify.rs
@@ -2,8 +2,8 @@ use itertools::Itertools;
 use rowifi_framework::prelude::*;
 use rowifi_models::{
     bind::{BindType, Rankbind},
-    roblox::id::GroupId,
     id::RoleId,
+    roblox::id::GroupId,
 };
 
 use super::new::PREFIX_REGEX;

--- a/rowifi/src/commands/rankbinds/modify.rs
+++ b/rowifi/src/commands/rankbinds/modify.rs
@@ -3,6 +3,7 @@ use rowifi_framework::prelude::*;
 use rowifi_models::{
     bind::{BindType, Rankbind},
     roblox::id::GroupId,
+    id::RoleId,
 };
 
 use super::new::PREFIX_REGEX;
@@ -199,13 +200,13 @@ async fn add_roles(
     ctx: &CommandContext,
     bind: &Rankbind,
     roles: &str,
-) -> Result<Vec<i64>, RoError> {
+) -> Result<Vec<RoleId>, RoError> {
     let mut role_ids = Vec::new();
     for r in roles.split_ascii_whitespace() {
         if let Some(resolved) = &ctx.resolved {
-            role_ids.extend(resolved.roles.iter().map(|r| r.0.get() as i64));
+            role_ids.extend(resolved.roles.iter().map(|r| RoleId(*r.0)));
         } else if let Some(r) = parse_role(r) {
-            role_ids.push(r as i64);
+            role_ids.push(r);
         }
     }
     role_ids = role_ids.into_iter().unique().collect::<Vec<_>>();
@@ -217,13 +218,13 @@ async fn remove_roles(
     ctx: &CommandContext,
     bind: &Rankbind,
     roles: &str,
-) -> Result<Vec<i64>, RoError> {
+) -> Result<Vec<RoleId>, RoError> {
     let mut role_ids = Vec::new();
     for r in roles.split_ascii_whitespace() {
         if let Some(resolved) = &ctx.resolved {
-            role_ids.extend(resolved.roles.iter().map(|r| r.0.get() as i64));
+            role_ids.extend(resolved.roles.iter().map(|r| RoleId(*r.0)));
         } else if let Some(r) = parse_role(r) {
-            role_ids.push(r as i64);
+            role_ids.push(r);
         }
     }
     role_ids = role_ids.into_iter().unique().collect::<Vec<_>>();

--- a/rowifi/src/commands/rankbinds/modify.rs
+++ b/rowifi/src/commands/rankbinds/modify.rs
@@ -35,7 +35,7 @@ pub async fn rankbinds_modify(ctx: CommandContext, args: ModifyRankbind) -> Comm
         .database
         .query::<Rankbind>(
             "SELECT * FROM binds WHERE guild_id = $1 AND bind_type = $2",
-            &[&(guild_id.get() as i64), &BindType::Rank],
+            &[&(guild_id), &BindType::Rank],
         )
         .await?;
 

--- a/rowifi/src/commands/rankbinds/new.rs
+++ b/rowifi/src/commands/rankbinds/new.rs
@@ -4,7 +4,7 @@ use regex::Regex;
 use rowifi_framework::prelude::*;
 use rowifi_models::{
     bind::{BindType, Rankbind, Template},
-    id::RoleId,
+    id::{BindId, RoleId},
     roblox::id::GroupId,
 };
 
@@ -164,7 +164,7 @@ pub async fn rankbinds_new(ctx: CommandContext, args: NewRankbind) -> CommandRes
         let rank_id = i64::from(roblox_rank.rank);
         let bind = Rankbind {
             // Don't care about the bind id here. The struct is only constructed to validate that all bind fields are being collected.
-            bind_id: 0,
+            bind_id: BindId::default(),
             group_id,
             group_rank_id: rank_id,
             roblox_rank_id: roblox_rank.id.0 as i64,

--- a/rowifi/src/commands/rankbinds/new.rs
+++ b/rowifi/src/commands/rankbinds/new.rs
@@ -2,10 +2,10 @@ use itertools::Itertools;
 use lazy_static::lazy_static;
 use regex::Regex;
 use rowifi_framework::prelude::*;
-use rowifi_models::discord::id::RoleId;
 use rowifi_models::{
     bind::{BindType, Rankbind, Template},
     roblox::id::GroupId,
+    id::RoleId,
 };
 
 #[derive(Debug, FromArgs)]
@@ -137,7 +137,7 @@ pub async fn rankbinds_new(ctx: CommandContext, args: NewRankbind) -> CommandRes
                     .iter()
                     .find(|r| r.name.eq_ignore_ascii_case(&roblox_rank.name))
                 {
-                    Some(r) => r.id.0.get() as i64,
+                    Some(r) => r.id,
                     None => {
                         let new_role = ctx
                             .bot
@@ -148,18 +148,18 @@ pub async fn rankbinds_new(ctx: CommandContext, args: NewRankbind) -> CommandRes
                             .await?
                             .model()
                             .await?;
-                        new_role.id.0.get() as i64
+                        RoleId(new_role.id)
                     }
                 };
                 roles.push(role);
             } else if let Some(resolved) = &ctx.resolved {
-                roles.extend(resolved.roles.iter().map(|r| r.0.get() as i64));
+                roles.extend(resolved.roles.iter().map(|r| RoleId(*r.0)));
             } else if let Some(role_id) = parse_role(role_to_add) {
                 if server_roles
                     .iter()
-                    .any(|r| r.id == RoleId::new(role_id).unwrap())
+                    .any(|r| r.id == role_id)
                 {
-                    roles.push(role_id as i64);
+                    roles.push(role_id);
                 }
             }
         }

--- a/rowifi/src/commands/rankbinds/new.rs
+++ b/rowifi/src/commands/rankbinds/new.rs
@@ -4,8 +4,8 @@ use regex::Regex;
 use rowifi_framework::prelude::*;
 use rowifi_models::{
     bind::{BindType, Rankbind, Template},
-    roblox::id::GroupId,
     id::RoleId,
+    roblox::id::GroupId,
 };
 
 #[derive(Debug, FromArgs)]
@@ -155,10 +155,7 @@ pub async fn rankbinds_new(ctx: CommandContext, args: NewRankbind) -> CommandRes
             } else if let Some(resolved) = &ctx.resolved {
                 roles.extend(resolved.roles.iter().map(|r| RoleId(*r.0)));
             } else if let Some(role_id) = parse_role(role_to_add) {
-                if server_roles
-                    .iter()
-                    .any(|r| r.id == role_id)
-                {
+                if server_roles.iter().any(|r| r.id == role_id) {
                     roles.push(role_id);
                 }
             }

--- a/rowifi/src/commands/rankbinds/new.rs
+++ b/rowifi/src/commands/rankbinds/new.rs
@@ -40,7 +40,7 @@ pub async fn rankbinds_new(ctx: CommandContext, args: NewRankbind) -> CommandRes
         .database
         .query::<Rankbind>(
             "SELECT * FROM binds WHERE guild_id = $1 AND bind_type = $2",
-            &[&(guild_id.0.get() as i64), &BindType::Rank],
+            &[&(guild_id), &BindType::Rank],
         )
         .await?;
     let server_roles = ctx.bot.cache.guild_roles(guild_id);
@@ -142,7 +142,7 @@ pub async fn rankbinds_new(ctx: CommandContext, args: NewRankbind) -> CommandRes
                         let new_role = ctx
                             .bot
                             .http
-                            .create_role(ctx.guild_id.unwrap())
+                            .create_role(ctx.guild_id.unwrap().0)
                             .name(&roblox_rank.name)
                             .exec()
                             .await?
@@ -202,7 +202,7 @@ pub async fn rankbinds_new(ctx: CommandContext, args: NewRankbind) -> CommandRes
                         &stmt,
                         &[
                             &BindType::Rank,
-                            &(guild_id.get() as i64),
+                            &(guild_id),
                             &bind.group_id,
                             &bind.group_rank_id,
                             &bind.roblox_rank_id,

--- a/rowifi/src/commands/settings/admin.rs
+++ b/rowifi/src/commands/settings/admin.rs
@@ -1,8 +1,8 @@
 use itertools::Itertools;
 use rowifi_framework::prelude::*;
 use rowifi_models::{
-    id::RoleId,
     guild::{GuildType, RoGuild},
+    id::RoleId,
 };
 
 use super::FunctionOption;
@@ -76,10 +76,7 @@ pub async fn admin_add(
         if let Some(resolved) = &ctx.resolved {
             roles_to_add.extend(resolved.roles.iter().map(|r| RoleId(*r.0)));
         } else if let Some(role_id) = parse_role(role) {
-            if server_roles
-                .iter()
-                .any(|r| r.id == role_id)
-            {
+            if server_roles.iter().any(|r| r.id == role_id) {
                 roles_to_add.push(role_id);
             }
         }
@@ -178,10 +175,7 @@ pub async fn admin_set(
         if let Some(resolved) = &ctx.resolved {
             roles_to_set.extend(resolved.roles.iter().map(|r| RoleId(*r.0)));
         } else if let Some(role_id) = parse_role(role) {
-            if server_roles
-                .iter()
-                .any(|r| r.id == role_id)
-            {
+            if server_roles.iter().any(|r| r.id == role_id) {
                 roles_to_set.push(role_id);
             }
         }
@@ -196,10 +190,9 @@ pub async fn admin_set(
         )
         .await?;
 
-    ctx.bot.admin_roles.insert(
-        guild_id,
-        roles_to_set.iter().cloned().collect(),
-    );
+    ctx.bot
+        .admin_roles
+        .insert(guild_id, roles_to_set.iter().cloned().collect());
 
     let mut description = "Set Admin Roles:\n".to_string();
     for role in roles_to_set {

--- a/rowifi/src/commands/settings/admin.rs
+++ b/rowifi/src/commands/settings/admin.rs
@@ -17,7 +17,7 @@ pub struct AdminArguments {
 
 pub async fn admin(ctx: CommandContext, args: AdminArguments) -> CommandResult {
     let guild_id = ctx.guild_id.unwrap();
-    let guild = ctx.bot.database.get_guild(guild_id.0.get() as i64).await?;
+    let guild = ctx.bot.database.get_guild(guild_id).await?;
 
     if guild.kind == GuildType::Free {
         let embed = EmbedBuilder::new()
@@ -137,7 +137,7 @@ pub async fn admin_remove(
         .database
         .execute(
             "UPDATE guilds SET admin_roles = $1 WHERE guild_id = $2",
-            &[&roles_to_keep, &(guild_id.get() as i64)],
+            &[&roles_to_keep, &(guild_id)],
         )
         .await?;
 

--- a/rowifi/src/commands/settings/bypass.rs
+++ b/rowifi/src/commands/settings/bypass.rs
@@ -1,8 +1,8 @@
 use itertools::Itertools;
 use rowifi_framework::prelude::*;
 use rowifi_models::{
-    id::RoleId,
     guild::{GuildType, RoGuild},
+    id::RoleId,
 };
 
 use super::FunctionOption;
@@ -79,10 +79,7 @@ pub async fn bypass_add(
         if let Some(resolved) = &ctx.resolved {
             roles_to_add.extend(resolved.roles.iter().map(|r| RoleId(*r.0)));
         } else if let Some(role_id) = parse_role(role) {
-            if server_roles
-                .iter()
-                .any(|r| r.id == role_id)
-            {
+            if server_roles.iter().any(|r| r.id == role_id) {
                 roles_to_add.push(role_id);
             }
         }
@@ -182,10 +179,7 @@ pub async fn bypass_set(
         if let Some(resolved) = &ctx.resolved {
             roles_to_set.extend(resolved.roles.iter().map(|r| RoleId(*r.0)));
         } else if let Some(role_id) = parse_role(role) {
-            if server_roles
-                .iter()
-                .any(|r| r.id == role_id)
-            {
+            if server_roles.iter().any(|r| r.id == role_id) {
                 roles_to_set.push(role_id);
             }
         }
@@ -200,10 +194,7 @@ pub async fn bypass_set(
         )
         .await?;
 
-    ctx.bot.bypass_roles.insert(
-        guild_id,
-        roles_to_set.clone(),
-    );
+    ctx.bot.bypass_roles.insert(guild_id, roles_to_set.clone());
 
     let mut description = "Set Bypass Roles:\n".to_string();
     for role in roles_to_set {

--- a/rowifi/src/commands/settings/bypass.rs
+++ b/rowifi/src/commands/settings/bypass.rs
@@ -17,7 +17,7 @@ pub struct BypassArguments {
 
 pub async fn bypass(ctx: CommandContext, args: BypassArguments) -> CommandResult {
     let guild_id = ctx.guild_id.unwrap();
-    let guild = ctx.bot.database.get_guild(guild_id.0.get() as i64).await?;
+    let guild = ctx.bot.database.get_guild(guild_id).await?;
 
     if guild.kind == GuildType::Free {
         let embed = EmbedBuilder::new()
@@ -141,7 +141,7 @@ pub async fn bypass_remove(
         .database
         .execute(
             "UPDATE guilds SET bypass_roles = $1 WHERE guild_id = $2",
-            &[&roles_to_keep, &(guild_id.get() as i64)],
+            &[&roles_to_keep, &(guild_id)],
         )
         .await?;
 

--- a/rowifi/src/commands/settings/functional.rs
+++ b/rowifi/src/commands/settings/functional.rs
@@ -1,7 +1,7 @@
 use rowifi_database::postgres::types::ToSql;
 use rowifi_framework::prelude::*;
 use rowifi_models::{
-    discord::id::RoleId,
+    id::RoleId,
     guild::{GuildType, RoGuild},
 };
 
@@ -101,7 +101,7 @@ pub async fn functional(ctx: CommandContext, args: FunctionalArguments) -> Comma
 
     let message_id = message.id;
     let author_id = ctx.author.id;
-    let role_id = args.role.0.get() as i64;
+    let role_id = args.role;
 
     let stream = ctx
         .bot
@@ -143,14 +143,14 @@ pub async fn functional(ctx: CommandContext, args: FunctionalArguments) -> Comma
                             .admin_roles
                             .entry(guild_id)
                             .or_default()
-                            .push(RoleId::new(role_id as u64).unwrap());
+                            .push(role_id);
                     } else if guild.admin_roles.contains(&role_id) {
                         updates.push(format!(
                             "admin_roles = array_remove(admin_roles, ${})",
                             updates.len() + 1
                         ));
                         if let Some(mut admin_roles) = ctx.bot.admin_roles.get_mut(&guild_id) {
-                            admin_roles.retain(|a| !a.eq(&args.role));
+                            admin_roles.retain(|a| !a.eq(&role_id));
                         }
                     }
 
@@ -169,14 +169,14 @@ pub async fn functional(ctx: CommandContext, args: FunctionalArguments) -> Comma
                             .trainer_roles
                             .entry(guild_id)
                             .or_default()
-                            .push(RoleId::new(role_id as u64).unwrap());
+                            .push(role_id);
                     } else if guild.trainer_roles.contains(&role_id) {
                         updates.push(format!(
                             "trainer_roles = array_remove(trainer_roles, ${})",
                             updates.len() + 1
                         ));
                         if let Some(mut trainer_roles) = ctx.bot.trainer_roles.get_mut(&guild_id) {
-                            trainer_roles.retain(|a| !a.eq(&args.role));
+                            trainer_roles.retain(|a| !a.eq(&role_id));
                         }
                     }
 
@@ -195,14 +195,14 @@ pub async fn functional(ctx: CommandContext, args: FunctionalArguments) -> Comma
                             .bypass_roles
                             .entry(guild_id)
                             .or_default()
-                            .push(RoleId::new(role_id as u64).unwrap());
+                            .push(role_id);
                     } else if guild.bypass_roles.contains(&role_id) {
                         updates.push(format!(
                             "bypass_roles = array_remove(bypass_roles, ${})",
                             updates.len() + 1
                         ));
                         if let Some(mut bypass_roles) = ctx.bot.bypass_roles.get_mut(&guild_id) {
-                            bypass_roles.retain(|a| !a.eq(&args.role));
+                            bypass_roles.retain(|a| !a.eq(&role_id));
                         }
                     }
 
@@ -221,7 +221,7 @@ pub async fn functional(ctx: CommandContext, args: FunctionalArguments) -> Comma
                             .nickname_bypass_roles
                             .entry(guild_id)
                             .or_default()
-                            .push(RoleId::new(role_id as u64).unwrap());
+                            .push(role_id);
                     } else if guild.nickname_bypass_roles.contains(&role_id) {
                         updates.push(format!(
                             "nickname_bypass_roles = array_remove(nickname_bypass_roles, ${})",
@@ -230,7 +230,7 @@ pub async fn functional(ctx: CommandContext, args: FunctionalArguments) -> Comma
                         if let Some(mut nickname_bypass_roles) =
                             ctx.bot.nickname_bypass_roles.get_mut(&guild_id)
                         {
-                            nickname_bypass_roles.retain(|a| !a.eq(&args.role));
+                            nickname_bypass_roles.retain(|a| !a.eq(&role_id));
                         }
                     }
 

--- a/rowifi/src/commands/settings/functional.rs
+++ b/rowifi/src/commands/settings/functional.rs
@@ -13,7 +13,7 @@ pub struct FunctionalArguments {
 
 pub async fn functional(ctx: CommandContext, args: FunctionalArguments) -> CommandResult {
     let guild_id = ctx.guild_id.unwrap();
-    let mut guild = ctx.bot.database.get_guild(guild_id.0.get() as i64).await?;
+    let mut guild = ctx.bot.database.get_guild(guild_id).await?;
 
     if guild.kind == GuildType::Free {
         let embed = EmbedBuilder::new()

--- a/rowifi/src/commands/settings/functional.rs
+++ b/rowifi/src/commands/settings/functional.rs
@@ -1,8 +1,8 @@
 use rowifi_database::postgres::types::ToSql;
 use rowifi_framework::prelude::*;
 use rowifi_models::{
-    id::RoleId,
     guild::{GuildType, RoGuild},
+    id::RoleId,
 };
 
 #[derive(FromArgs)]

--- a/rowifi/src/commands/settings/log.rs
+++ b/rowifi/src/commands/settings/log.rs
@@ -1,5 +1,5 @@
 use rowifi_framework::prelude::*;
-use rowifi_models::{discord::id::ChannelId, guild::GuildType};
+use rowifi_models::{id::ChannelId, guild::GuildType};
 
 #[derive(FromArgs)]
 pub struct LogChannelArguments {

--- a/rowifi/src/commands/settings/log.rs
+++ b/rowifi/src/commands/settings/log.rs
@@ -1,5 +1,5 @@
 use rowifi_framework::prelude::*;
-use rowifi_models::{id::ChannelId, guild::GuildType};
+use rowifi_models::{guild::GuildType, id::ChannelId};
 
 #[derive(FromArgs)]
 pub struct LogChannelArguments {

--- a/rowifi/src/commands/settings/log.rs
+++ b/rowifi/src/commands/settings/log.rs
@@ -9,7 +9,7 @@ pub struct LogChannelArguments {
 
 pub async fn log_channel(ctx: CommandContext, args: LogChannelArguments) -> CommandResult {
     let guild_id = ctx.guild_id.unwrap();
-    let guild = ctx.bot.database.get_guild(guild_id.0.get() as i64).await?;
+    let guild = ctx.bot.database.get_guild(guild_id).await?;
 
     if guild.kind == GuildType::Free {
         let embed = EmbedBuilder::new()

--- a/rowifi/src/commands/settings/misc.rs
+++ b/rowifi/src/commands/settings/misc.rs
@@ -16,7 +16,7 @@ pub async fn blacklist_action(
     args: BlacklistActionArguments,
 ) -> CommandResult {
     let guild_id = ctx.guild_id.unwrap();
-    let guild = ctx.bot.database.get_guild(guild_id.0.get() as i64).await?;
+    let guild = ctx.bot.database.get_guild(guild_id).await?;
 
     let bl_type = args.option;
     ctx.bot
@@ -62,7 +62,7 @@ pub struct ToggleCommandsArguments {
 
 pub async fn toggle_commands(ctx: CommandContext, args: ToggleCommandsArguments) -> CommandResult {
     let guild_id = ctx.guild_id.unwrap();
-    let guild = ctx.bot.database.get_guild(guild_id.0.get() as i64).await?;
+    let guild = ctx.bot.database.get_guild(guild_id).await?;
 
     let option = args.option;
     let (statement, desc, add) = match option {
@@ -111,7 +111,7 @@ pub struct SettingsPrefixArguments {
 
 pub async fn settings_prefix(ctx: CommandContext, args: SettingsPrefixArguments) -> CommandResult {
     let guild_id = ctx.guild_id.unwrap();
-    let guild = ctx.bot.database.get_guild(guild_id.0.get() as i64).await?;
+    let guild = ctx.bot.database.get_guild(guild_id).await?;
 
     let prefix = args.prefix;
     ctx.bot

--- a/rowifi/src/commands/settings/mod.rs
+++ b/rowifi/src/commands/settings/mod.rs
@@ -123,7 +123,7 @@ pub fn settings_config(cmds: &mut Vec<Command>) {
 
 pub async fn settings_view(ctx: CommandContext) -> CommandResult {
     let guild_id = ctx.guild_id.unwrap();
-    let guild = ctx.bot.database.get_guild(guild_id.0.get() as i64).await?;
+    let guild = ctx.bot.database.get_guild(guild_id).await?;
 
     let embed = EmbedBuilder::new()
         .default_data()

--- a/rowifi/src/commands/settings/nickname_bypass.rs
+++ b/rowifi/src/commands/settings/nickname_bypass.rs
@@ -19,7 +19,7 @@ pub struct NicknameBypassArguments {
 
 pub async fn nickname_bypass(ctx: CommandContext, args: NicknameBypassArguments) -> CommandResult {
     let guild_id = ctx.guild_id.unwrap();
-    let guild = ctx.bot.database.get_guild(guild_id.0.get() as i64).await?;
+    let guild = ctx.bot.database.get_guild(guild_id).await?;
 
     if guild.kind == GuildType::Free {
         let embed = EmbedBuilder::new()
@@ -148,7 +148,7 @@ pub async fn nickname_bypass_remove(
         .database
         .execute(
             "UPDATE guilds SET nickname_bypass_roles = $1 WHERE guild_id = $2",
-            &[&roles_to_keep, &(guild_id.get() as i64)],
+            &[&roles_to_keep, &(guild_id)],
         )
         .await?;
 

--- a/rowifi/src/commands/settings/nickname_bypass.rs
+++ b/rowifi/src/commands/settings/nickname_bypass.rs
@@ -1,8 +1,8 @@
 use itertools::Itertools;
 use rowifi_framework::prelude::*;
 use rowifi_models::{
-    id::RoleId,
     guild::{GuildType, RoGuild},
+    id::RoleId,
 };
 
 use super::FunctionOption;
@@ -86,10 +86,7 @@ pub async fn nickname_bypass_add(
         if let Some(resolved) = &ctx.resolved {
             roles_to_add.extend(resolved.roles.iter().map(|r| RoleId(*r.0)));
         } else if let Some(role_id) = parse_role(role) {
-            if server_roles
-                .iter()
-                .any(|r| r.id == role_id)
-            {
+            if server_roles.iter().any(|r| r.id == role_id) {
                 roles_to_add.push(role_id);
             }
         }
@@ -189,10 +186,7 @@ pub async fn nickname_bypass_set(
         if let Some(resolved) = &ctx.resolved {
             roles_to_set.extend(resolved.roles.iter().map(|r| RoleId(*r.0)));
         } else if let Some(role_id) = parse_role(role) {
-            if server_roles
-                .iter()
-                .any(|r| r.id == role_id)
-            {
+            if server_roles.iter().any(|r| r.id == role_id) {
                 roles_to_set.push(role_id);
             }
         }
@@ -207,10 +201,9 @@ pub async fn nickname_bypass_set(
         )
         .await?;
 
-    ctx.bot.nickname_bypass_roles.insert(
-        guild_id,
-        roles_to_set.clone(),
-    );
+    ctx.bot
+        .nickname_bypass_roles
+        .insert(guild_id, roles_to_set.clone());
 
     let mut description = "Set Nickname Bypass Roles:\n".to_string();
     for role in roles_to_set {

--- a/rowifi/src/commands/settings/trainer.rs
+++ b/rowifi/src/commands/settings/trainer.rs
@@ -1,8 +1,8 @@
 use itertools::Itertools;
 use rowifi_framework::prelude::*;
 use rowifi_models::{
-    id::RoleId,
     guild::{GuildType, RoGuild},
+    id::RoleId,
 };
 
 use super::FunctionOption;
@@ -83,10 +83,7 @@ pub async fn trainer_add(
         if let Some(resolved) = &ctx.resolved {
             roles_to_add.extend(resolved.roles.iter().map(|r| RoleId(*r.0)));
         } else if let Some(role_id) = parse_role(role) {
-            if server_roles
-                .iter()
-                .any(|r| r.id == role_id)
-            {
+            if server_roles.iter().any(|r| r.id == role_id) {
                 roles_to_add.push(role_id);
             }
         }
@@ -185,10 +182,7 @@ pub async fn trainer_set(
         if let Some(resolved) = &ctx.resolved {
             roles_to_set.extend(resolved.roles.iter().map(|r| RoleId(*r.0)));
         } else if let Some(role_id) = parse_role(role) {
-            if server_roles
-                .iter()
-                .any(|r| r.id == role_id)
-            {
+            if server_roles.iter().any(|r| r.id == role_id) {
                 roles_to_set.push(role_id);
             }
         }
@@ -203,10 +197,7 @@ pub async fn trainer_set(
         )
         .await?;
 
-    ctx.bot.trainer_roles.insert(
-        guild_id,
-        roles_to_set.clone(),
-    );
+    ctx.bot.trainer_roles.insert(guild_id, roles_to_set.clone());
 
     let mut description = "Set Trainer Roles:\n".to_string();
     for role in roles_to_set {

--- a/rowifi/src/commands/settings/trainer.rs
+++ b/rowifi/src/commands/settings/trainer.rs
@@ -17,7 +17,7 @@ pub struct TrainerArguments {
 
 pub async fn trainer(ctx: CommandContext, args: TrainerArguments) -> CommandResult {
     let guild_id = ctx.guild_id.unwrap();
-    let guild = ctx.bot.database.get_guild(guild_id.0.get() as i64).await?;
+    let guild = ctx.bot.database.get_guild(guild_id).await?;
 
     if guild.kind == GuildType::Free {
         let embed = EmbedBuilder::new()
@@ -144,7 +144,7 @@ pub async fn trainer_remove(
         .database
         .execute(
             "UPDATE guilds SET trainer_roles = $1 WHERE guild_id = $2",
-            &[&roles_to_keep, &(guild_id.get() as i64)],
+            &[&roles_to_keep, &(guild_id)],
         )
         .await?;
 

--- a/rowifi/src/commands/settings/trainer.rs
+++ b/rowifi/src/commands/settings/trainer.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 use rowifi_framework::prelude::*;
 use rowifi_models::{
-    discord::id::RoleId,
+    id::RoleId,
     guild::{GuildType, RoGuild},
 };
 
@@ -81,13 +81,13 @@ pub async fn trainer_add(
     let mut roles_to_add = Vec::new();
     for role in roles {
         if let Some(resolved) = &ctx.resolved {
-            roles_to_add.extend(resolved.roles.iter().map(|r| r.0.get() as i64));
+            roles_to_add.extend(resolved.roles.iter().map(|r| RoleId(*r.0)));
         } else if let Some(role_id) = parse_role(role) {
             if server_roles
                 .iter()
-                .any(|r| r.id == RoleId::new(role_id).unwrap())
+                .any(|r| r.id == role_id)
             {
-                roles_to_add.push(role_id as i64);
+                roles_to_add.push(role_id);
             }
         }
     }
@@ -95,7 +95,7 @@ pub async fn trainer_add(
 
     {
         let trainer_roles = ctx.bot.trainer_roles.entry(guild_id).or_default();
-        roles_to_add.retain(|r| !trainer_roles.contains(&RoleId::new(*r as u64).unwrap()));
+        roles_to_add.retain(|r| !trainer_roles.contains(r));
     }
 
     ctx.bot.database.execute("UPDATE guilds SET trainer_roles = array_cat(trainer_roles, $1::BIGINT[]) WHERE guild_id = $2", &[&roles_to_add, &guild.guild_id]).await?;
@@ -104,7 +104,7 @@ pub async fn trainer_add(
         .trainer_roles
         .entry(guild_id)
         .or_default()
-        .extend(roles_to_add.iter().map(|r| RoleId::new(*r as u64).unwrap()));
+        .extend(&roles_to_add);
 
     let mut description = "Added Trainer Roles:\n".to_string();
     for role in roles_to_add {
@@ -132,9 +132,9 @@ pub async fn trainer_remove(
     let mut role_ids = Vec::new();
     for r in discord_roles.split_ascii_whitespace() {
         if let Some(resolved) = &ctx.resolved {
-            role_ids.extend(resolved.roles.iter().map(|r| r.0.get() as i64));
+            role_ids.extend(resolved.roles.iter().map(|r| RoleId(*r.0)));
         } else if let Some(r) = parse_role(r) {
-            role_ids.push(r as i64);
+            role_ids.push(r);
         }
     }
 
@@ -152,7 +152,7 @@ pub async fn trainer_remove(
         .trainer_roles
         .entry(guild_id)
         .or_default()
-        .retain(|r| !role_ids.contains(&(r.0.get() as i64)));
+        .retain(|r| !role_ids.contains(r));
 
     let mut description = "Removed Trainer Roles:\n".to_string();
     for role in role_ids {
@@ -183,13 +183,13 @@ pub async fn trainer_set(
     let mut roles_to_set = Vec::new();
     for role in roles {
         if let Some(resolved) = &ctx.resolved {
-            roles_to_set.extend(resolved.roles.iter().map(|r| r.0.get() as i64));
+            roles_to_set.extend(resolved.roles.iter().map(|r| RoleId(*r.0)));
         } else if let Some(role_id) = parse_role(role) {
             if server_roles
                 .iter()
-                .any(|r| r.id == RoleId::new(role_id).unwrap())
+                .any(|r| r.id == role_id)
             {
-                roles_to_set.push(role_id as i64);
+                roles_to_set.push(role_id);
             }
         }
     }
@@ -205,10 +205,7 @@ pub async fn trainer_set(
 
     ctx.bot.trainer_roles.insert(
         guild_id,
-        roles_to_set
-            .iter()
-            .map(|r| RoleId::new(*r as u64).unwrap())
-            .collect(),
+        roles_to_set.clone(),
     );
 
     let mut description = "Set Trainer Roles:\n".to_string();

--- a/rowifi/src/commands/settings/update.rs
+++ b/rowifi/src/commands/settings/update.rs
@@ -10,7 +10,7 @@ pub struct UpdateOnJoinArguments {
 
 pub async fn update_on_join(ctx: CommandContext, args: UpdateOnJoinArguments) -> CommandResult {
     let guild_id = ctx.guild_id.unwrap();
-    let guild = ctx.bot.database.get_guild(guild_id.0.get() as i64).await?;
+    let guild = ctx.bot.database.get_guild(guild_id).await?;
 
     let option = args.option;
     let (option, desc) = match option {

--- a/rowifi/src/commands/settings/verify.rs
+++ b/rowifi/src/commands/settings/verify.rs
@@ -1,5 +1,5 @@
 use rowifi_framework::prelude::*;
-use rowifi_models::discord::id::RoleId;
+use rowifi_models::id::RoleId;
 
 #[derive(FromArgs)]
 pub struct VerificationArguments {

--- a/rowifi/src/commands/settings/verify.rs
+++ b/rowifi/src/commands/settings/verify.rs
@@ -12,7 +12,7 @@ pub async fn settings_verification(
     args: VerificationArguments,
 ) -> CommandResult {
     let guild_id = ctx.guild_id.unwrap();
-    let guild = ctx.bot.database.get_guild(guild_id.0.get() as i64).await?;
+    let guild = ctx.bot.database.get_guild(guild_id).await?;
 
     let verification_roles = vec![args.role.get() as i64];
     ctx.bot
@@ -56,7 +56,7 @@ pub struct VerifiedArguments {
 
 pub async fn settings_verified(ctx: CommandContext, args: VerifiedArguments) -> CommandResult {
     let guild_id = ctx.guild_id.unwrap();
-    let guild = ctx.bot.database.get_guild(guild_id.0.get() as i64).await?;
+    let guild = ctx.bot.database.get_guild(guild_id).await?;
 
     let verified_roles = vec![args.role.get() as i64];
     ctx.bot

--- a/rowifi/src/commands/user/info.rs
+++ b/rowifi/src/commands/user/info.rs
@@ -1,7 +1,8 @@
 use rowifi_framework::prelude::*;
 use rowifi_models::{
-    discord::id::{GuildId, UserId},
+    discord::id::{UserId},
     roblox::id::UserId as RobloxUserId,
+    id::GuildId,
 };
 
 #[derive(FromArgs)]
@@ -35,7 +36,7 @@ pub async fn userinfo(ctx: CommandContext, args: UserInfoArguments) -> CommandRe
     let user = match ctx
         .bot
         .database
-        .get_linked_user(author.0.get() as i64, ctx.guild_id.unwrap().get() as i64)
+        .get_linked_user(author.0.get() as i64, ctx.guild_id.unwrap())
         .await?
     {
         Some(u) => u,
@@ -89,7 +90,7 @@ pub async fn botinfo(ctx: CommandContext) -> CommandResult {
     let guilds = ctx.bot.cache.guilds();
     let member_count: i64 = guilds
         .iter()
-        .map(|g| ctx.bot.cache.member_count(GuildId::new(*g).unwrap()))
+        .map(|g| ctx.bot.cache.member_count(GuildId::new(*g)))
         .sum();
 
     let embed = EmbedBuilder::new()

--- a/rowifi/src/commands/user/info.rs
+++ b/rowifi/src/commands/user/info.rs
@@ -1,8 +1,7 @@
 use rowifi_framework::prelude::*;
 use rowifi_models::{
-    discord::id::{UserId},
     roblox::id::UserId as RobloxUserId,
-    id::GuildId,
+    id::{GuildId, UserId},
 };
 
 #[derive(FromArgs)]
@@ -17,7 +16,7 @@ pub async fn userinfo(ctx: CommandContext, args: UserInfoArguments) -> CommandRe
         if let Some(u) = u {
             (u.user.id, u.user.name.clone())
         } else {
-            let author_user = ctx.member(guild_id, ctx.author.id).await?;
+            let author_user = ctx.member(guild_id, UserId(ctx.author.id)).await?;
             if let Some(a) = author_user {
                 (a.user.id, a.user.name.clone())
             } else {
@@ -25,7 +24,7 @@ pub async fn userinfo(ctx: CommandContext, args: UserInfoArguments) -> CommandRe
             }
         }
     } else {
-        let author_user = ctx.member(guild_id, ctx.author.id).await?;
+        let author_user = ctx.member(guild_id, UserId(ctx.author.id)).await?;
         if let Some(a) = author_user {
             (a.user.id, a.user.name.clone())
         } else {
@@ -36,7 +35,7 @@ pub async fn userinfo(ctx: CommandContext, args: UserInfoArguments) -> CommandRe
     let user = match ctx
         .bot
         .database
-        .get_linked_user(author.0.get() as i64, ctx.guild_id.unwrap())
+        .get_linked_user(UserId(author.0), ctx.guild_id.unwrap())
         .await?
     {
         Some(u) => u,

--- a/rowifi/src/commands/user/info.rs
+++ b/rowifi/src/commands/user/info.rs
@@ -1,7 +1,7 @@
 use rowifi_framework::prelude::*;
 use rowifi_models::{
-    roblox::id::UserId as RobloxUserId,
     id::{GuildId, UserId},
+    roblox::id::UserId as RobloxUserId,
 };
 
 #[derive(FromArgs)]

--- a/rowifi/src/commands/user/update.rs
+++ b/rowifi/src/commands/user/update.rs
@@ -166,7 +166,7 @@ pub async fn update_func(
     let user = match ctx
         .bot
         .database
-        .get_linked_user(user_id.get() as i64, guild_id.get() as i64)
+        .get_linked_user(user_id.get() as i64, guild_id)
         .await?
     {
         Some(u) => u,
@@ -182,13 +182,13 @@ pub async fn update_func(
         }
     };
 
-    let guild = ctx.bot.database.get_guild(guild_id.0.get() as i64).await?;
+    let guild = ctx.bot.database.get_guild(guild_id).await?;
     let binds = ctx
         .bot
         .database
         .query::<Bind>(
             "SELECT * FROM binds WHERE guild_id = $1",
-            &[&(guild_id.get() as i64)],
+            &[&(guild_id)],
         )
         .await?;
     let all_roles = binds

--- a/rowifi/src/commands/user/update.rs
+++ b/rowifi/src/commands/user/update.rs
@@ -161,12 +161,7 @@ pub async fn update_func(
         return Ok(embed);
     }
 
-    let user = match ctx
-        .bot
-        .database
-        .get_linked_user(user_id, guild_id)
-        .await?
-    {
+    let user = match ctx.bot.database.get_linked_user(user_id, guild_id).await? {
         Some(u) => u,
         None => {
             let embed = EmbedBuilder::new()
@@ -184,10 +179,7 @@ pub async fn update_func(
     let binds = ctx
         .bot
         .database
-        .query::<Bind>(
-            "SELECT * FROM binds WHERE guild_id = $1",
-            &[&(guild_id)],
-        )
+        .query::<Bind>("SELECT * FROM binds WHERE guild_id = $1", &[&(guild_id)])
         .await?;
     let all_roles = binds
         .iter()

--- a/rowifi/src/commands/user/update.rs
+++ b/rowifi/src/commands/user/update.rs
@@ -4,8 +4,9 @@ use rowifi_models::{
     bind::Bind,
     discord::{
         channel::embed::Embed,
-        id::{RoleId, UserId},
+        id::{UserId},
     },
+    id::RoleId,
 };
 use std::error::Error;
 use twilight_http::error::{Error as DiscordHttpError, ErrorType as DiscordErrorType};

--- a/rowifi/src/commands/user/update.rs
+++ b/rowifi/src/commands/user/update.rs
@@ -2,11 +2,8 @@ use itertools::Itertools;
 use rowifi_framework::prelude::*;
 use rowifi_models::{
     bind::Bind,
-    discord::{
-        channel::embed::Embed,
-        id::{UserId},
-    },
-    id::RoleId,
+    discord::channel::embed::Embed,
+    id::{RoleId, UserId},
 };
 use std::error::Error;
 use twilight_http::error::{Error as DiscordHttpError, ErrorType as DiscordErrorType};
@@ -121,7 +118,7 @@ pub async fn update_func(
 
     let user_id = match args.user_id {
         Some(s) => s,
-        None => ctx.author.id,
+        None => UserId(ctx.author.id),
     };
 
     let member = match ctx.member(guild_id, user_id).await? {
@@ -139,7 +136,7 @@ pub async fn update_func(
     };
 
     //Check for server owner
-    if server.owner_id.0 == member.user.id.0 {
+    if server.owner_id.0 == member.user.id {
         let embed = EmbedBuilder::new()
             .default_data()
             .title("Update Failed")
@@ -167,7 +164,7 @@ pub async fn update_func(
     let user = match ctx
         .bot
         .database
-        .get_linked_user(user_id.get() as i64, guild_id)
+        .get_linked_user(user_id, guild_id)
         .await?
     {
         Some(u) => u,
@@ -257,7 +254,7 @@ pub async fn update_func(
                 if let Ok(channel) = ctx
                     .bot
                     .http
-                    .create_private_channel(user_id)
+                    .create_private_channel(user_id.0)
                     .exec()
                     .await?
                     .model()

--- a/rowifi/src/commands/user/verify/manage.rs
+++ b/rowifi/src/commands/user/verify/manage.rs
@@ -1,5 +1,5 @@
 use rowifi_framework::prelude::*;
-use rowifi_models::user::RoGuildUser;
+use rowifi_models::{user::RoGuildUser, id::UserId};
 
 use crate::commands::handle_update_button;
 
@@ -67,7 +67,7 @@ pub async fn verify_switch(ctx: CommandContext, args: VerifyArguments) -> Comman
 
     let linked_user = RoGuildUser {
         guild_id: guild_id,
-        discord_id: ctx.author.id.0.get() as i64,
+        discord_id: UserId(ctx.author.id),
         roblox_id,
     };
 

--- a/rowifi/src/commands/user/verify/manage.rs
+++ b/rowifi/src/commands/user/verify/manage.rs
@@ -66,7 +66,7 @@ pub async fn verify_switch(ctx: CommandContext, args: VerifyArguments) -> Comman
     }
 
     let linked_user = RoGuildUser {
-        guild_id: guild_id.0.get() as i64,
+        guild_id: guild_id,
         discord_id: ctx.author.id.0.get() as i64,
         roblox_id,
     };

--- a/rowifi/src/commands/user/verify/manage.rs
+++ b/rowifi/src/commands/user/verify/manage.rs
@@ -1,5 +1,5 @@
 use rowifi_framework::prelude::*;
-use rowifi_models::{user::RoGuildUser, id::UserId};
+use rowifi_models::{id::UserId, user::RoGuildUser};
 
 use crate::commands::handle_update_button;
 
@@ -66,7 +66,7 @@ pub async fn verify_switch(ctx: CommandContext, args: VerifyArguments) -> Comman
     }
 
     let linked_user = RoGuildUser {
-        guild_id: guild_id,
+        guild_id,
         discord_id: UserId(ctx.author.id),
         roblox_id,
     };

--- a/rowifi/src/commands/user/verify/mod.rs
+++ b/rowifi/src/commands/user/verify/mod.rs
@@ -258,7 +258,7 @@ pub async fn verify_view(ctx: CommandContext) -> CommandResult {
     let linked_user = ctx
         .bot
         .database
-        .get_linked_user(ctx.author.id.0.get() as i64, guild_id.0.get() as i64)
+        .get_linked_user(ctx.author.id.0.get() as i64, guild_id)
         .await?;
 
     let embed = EmbedBuilder::new()

--- a/rowifi/src/commands/user/verify/mod.rs
+++ b/rowifi/src/commands/user/verify/mod.rs
@@ -7,6 +7,7 @@ use rowifi_models::{
         button::{Button, ButtonStyle},
         Component,
     },
+    id::UserId,
     roblox::id::UserId as RobloxUserId,
     user::QueueUser,
 };
@@ -218,7 +219,7 @@ pub async fn verify_common(
         .await?;
     let q_user = QueueUser {
         roblox_id,
-        discord_id: ctx.author.id.0.get() as i64,
+        discord_id: UserId(ctx.author.id),
         verified,
     };
     ctx.bot.database.execute("INSERT INTO queue VALUES($1, $2, $3) ON CONFLICT(roblox_id) DO UPDATE SET discord_id = $2, verified = $3", &[&q_user.roblox_id, &q_user.discord_id, &q_user.verified]).await?;
@@ -258,7 +259,7 @@ pub async fn verify_view(ctx: CommandContext) -> CommandResult {
     let linked_user = ctx
         .bot
         .database
-        .get_linked_user(ctx.author.id.0.get() as i64, guild_id)
+        .get_linked_user(UserId(ctx.author.id), guild_id)
         .await?;
 
     let embed = EmbedBuilder::new()

--- a/rowifi/src/main.rs
+++ b/rowifi/src/main.rs
@@ -36,6 +36,7 @@ use rowifi_framework::{context::BotContext, Framework};
 use rowifi_models::{
     discord::{gateway::Intents, guild::Permissions},
     stats::BotStats,
+    id::UserId,
 };
 use services::EventHandler;
 use std::{
@@ -151,7 +152,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .await?
         .model()
         .await?;
-    let owner = current_user.owner.id;
+    let owner = UserId(current_user.owner.id);
     http.set_application_id(current_user.id);
     owners.push(owner);
 

--- a/rowifi/src/main.rs
+++ b/rowifi/src/main.rs
@@ -35,8 +35,8 @@ use rowifi_database::Database;
 use rowifi_framework::{context::BotContext, Framework};
 use rowifi_models::{
     discord::{gateway::Intents, guild::Permissions},
-    stats::BotStats,
     id::UserId,
+    stats::BotStats,
 };
 use services::EventHandler;
 use std::{

--- a/rowifi/src/services/auto_detection.rs
+++ b/rowifi/src/services/auto_detection.rs
@@ -8,13 +8,13 @@ use rowifi_models::{
     bind::Bind,
     discord::{
         gateway::{event::Event, payload::outgoing::RequestGuildMembers},
-        id::{RoleId, UserId},
+        id::{UserId},
     },
     guild::{GuildType, RoGuild},
     roblox::id::UserId as RobloxUserId,
     user::RoGuildUser,
     FromRow,
-    id::GuildId,
+    id::{GuildId, RoleId},
 };
 use std::{collections::HashSet, env, error::Error, sync::atomic::Ordering};
 use tokio::time::{interval, sleep, timeout, Duration};
@@ -161,7 +161,7 @@ pub async fn execute_chunk(
     auto_detection: bool,
     role_filter: Option<RoleId>,
     binds: &[Bind],
-    all_roles: &[&i64],
+    all_roles: &[&RoleId],
 ) -> Result<(), RoError> {
     let log = if auto_detection {
         "Auto Detection"

--- a/rowifi/src/services/auto_detection.rs
+++ b/rowifi/src/services/auto_detection.rs
@@ -8,13 +8,13 @@ use rowifi_models::{
     bind::Bind,
     discord::{
         gateway::{event::Event, payload::outgoing::RequestGuildMembers},
-        id::{UserId},
+        id::UserId,
     },
     guild::{GuildType, RoGuild},
+    id::{GuildId, RoleId},
     roblox::id::UserId as RobloxUserId,
     user::RoGuildUser,
     FromRow,
-    id::{GuildId, RoleId},
 };
 use std::{collections::HashSet, env, error::Error, sync::atomic::Ordering};
 use tokio::time::{interval, sleep, timeout, Duration};
@@ -169,10 +169,7 @@ pub async fn execute_chunk(
         "Mass Update"
     };
     for user in user_chunk {
-        if let Some(member) = ctx
-            .cache
-            .member(server.id, user.discord_id)
-        {
+        if let Some(member) = ctx.cache.member(server.id, user.discord_id) {
             if let Some(role_filter) = role_filter {
                 if !member.roles.contains(&role_filter) {
                     continue;

--- a/rowifi/src/services/auto_detection.rs
+++ b/rowifi/src/services/auto_detection.rs
@@ -171,7 +171,7 @@ pub async fn execute_chunk(
     for user in user_chunk {
         if let Some(member) = ctx
             .cache
-            .member(server.id, UserId::new(user.discord_id as u64).unwrap())
+            .member(server.id, user.discord_id)
         {
             if let Some(role_filter) = role_filter {
                 if !member.roles.contains(&role_filter) {

--- a/rowifi/src/services/event_handler.rs
+++ b/rowifi/src/services/event_handler.rs
@@ -7,7 +7,7 @@ use rowifi_models::{
     discord::{
         channel::GuildChannel,
         guild::Permissions,
-        id::{ChannelId, RoleId},
+        id::{ChannelId},
     },
     id::GuildId,
     guild::{GuildType, RoGuild},
@@ -157,10 +157,10 @@ impl Service<(u64, Event)> for EventHandler {
                         }
 
                         if guild.kind != GuildType::Free {
-                            eh.bot.admin_roles.insert(guild_id, guild.admin_roles.into_iter().map(|a| RoleId::new(a as u64).unwrap()).collect());
-                            eh.bot.trainer_roles.insert(guild_id, guild.trainer_roles.into_iter().map(|t| RoleId::new(t as u64).unwrap()).collect());
-                            eh.bot.bypass_roles.insert(guild_id, guild.bypass_roles.into_iter().map(|b| RoleId::new(b as u64).unwrap()).collect());
-                            eh.bot.nickname_bypass_roles.insert(guild_id, guild.nickname_bypass_roles.into_iter().map(|nb| RoleId::new(nb as u64).unwrap()).collect());
+                            eh.bot.admin_roles.insert(guild_id, guild.admin_roles);
+                            eh.bot.trainer_roles.insert(guild_id, guild.trainer_roles);
+                            eh.bot.bypass_roles.insert(guild_id, guild.bypass_roles);
+                            eh.bot.nickname_bypass_roles.insert(guild_id, guild.nickname_bypass_roles);
                         }
 
                         if let Some(log_channel) = guild.log_channel {
@@ -189,8 +189,8 @@ impl Service<(u64, Event)> for EventHandler {
                         Some(u) => u,
                         None => {
                             if let Some(verification_role) = guild.verification_roles.get(0) {
-                                if let Some(role) = eh.bot.cache.role(RoleId::new(*verification_role as u64).unwrap()) {
-                                    eh.bot.http.add_guild_member_role(m.guild_id, m.user.id, role.id).exec().await?;
+                                if let Some(role) = eh.bot.cache.role(*verification_role) {
+                                    eh.bot.http.add_guild_member_role(m.guild_id, m.user.id, role.id.0).exec().await?;
                                 }
                             }
                             return Ok(());

--- a/rowifi/src/services/event_handler.rs
+++ b/rowifi/src/services/event_handler.rs
@@ -4,12 +4,9 @@ use itertools::Itertools;
 use rowifi_framework::{context::BotContext, prelude::*};
 use rowifi_models::{
     bind::Bind,
-    discord::{
-        channel::GuildChannel,
-        guild::Permissions,
-    },
-    id::{GuildId, ChannelId, UserId},
+    discord::{channel::GuildChannel, guild::Permissions},
     guild::{GuildType, RoGuild},
+    id::{ChannelId, GuildId, UserId},
 };
 use std::{
     pin::Pin,

--- a/rowifi/src/utils/update_user.rs
+++ b/rowifi/src/utils/update_user.rs
@@ -94,7 +94,7 @@ impl UpdateUser<'_> {
                         let _ = self
                             .ctx
                             .http
-                            .remove_guild_member(self.server.id, self.member.user.id)
+                            .remove_guild_member(self.server.id.0, self.member.user.id)
                             .exec()
                             .await;
                     }
@@ -102,7 +102,7 @@ impl UpdateUser<'_> {
                         let _ = self
                             .ctx
                             .http
-                            .create_ban(self.server.id, self.member.user.id)
+                            .create_ban(self.server.id.0, self.member.user.id)
                             .exec()
                             .await;
                     }
@@ -219,7 +219,7 @@ impl UpdateUser<'_> {
         let update = self
             .ctx
             .http
-            .update_guild_member(self.server.id, self.member.user.id);
+            .update_guild_member(self.server.id.0, self.member.user.id);
         let role_changes = !added_roles.is_empty() || !removed_roles.is_empty();
         let mut roles = self.member.roles.clone();
         roles.extend_from_slice(&added_roles);

--- a/rowifi/src/utils/update_user.rs
+++ b/rowifi/src/utils/update_user.rs
@@ -3,8 +3,8 @@ use rowifi_cache::{CachedGuild, CachedMember};
 use rowifi_framework::{context::BotContext, error::RoError};
 use rowifi_models::{
     bind::Bind,
-    id::RoleId,
     guild::{BlacklistActionType, RoGuild},
+    id::RoleId,
     roblox::id::{AssetId as RobloxAssetId, UserId as RobloxUserId},
     rolang::RoCommandUser,
     user::RoGuildUser,


### PR DESCRIPTION
The PR wraps over the twilight IDs to make it more seamless to interface with the database as well as with JSON, especially with 64-bit integers. The `rowifi-models` crate is reused by the API. It also converts some of the IDs to UUIDs instead of serials.