### PR TITLE
fix: show custombinds in text file if code greater than 1024 characters

### DIFF
--- a/framework/src/constants.rs
+++ b/framework/src/constants.rs
@@ -1,0 +1,2 @@
+pub const EMBED_DESCRIPTION_LIMIT: usize = 4096;
+pub const EMBED_FIELD_DESCRIPTION_LIMIT: usize = 1024;

--- a/framework/src/lib.rs
+++ b/framework/src/lib.rs
@@ -16,6 +16,7 @@
 pub mod arguments;
 pub mod bucket;
 pub mod command;
+pub mod constants;
 pub mod context;
 pub mod error;
 pub mod extensions;


### PR DESCRIPTION
The PR shows custombinds in a text file if the `code` field is greater than 1024 characters. It also adds in a constants module which can be used to hold discord, database or bot limits.