### PR TITLE
Fix error on entering invalid group ID when creating a rankbind

### DIFF
--- a/roblox/src/lib.rs
+++ b/roblox/src/lib.rs
@@ -247,7 +247,7 @@ impl Client {
                     route: _,
                 } = err.kind()
                 {
-                    if *status == StatusCode::NOT_FOUND {
+                    if *status == StatusCode::BAD_REQUEST {
                         return Ok(None);
                     }
                 }


### PR DESCRIPTION
The `get_group_ranks` was checking for the 404 status code when it was supposed to be checking for 400. This PR fixes it.