### PR TITLE
feat: add command to toggle auto detection

### DIFF
--- a/rowifi/src/commands/premium/redeem.rs
+++ b/rowifi/src/commands/premium/redeem.rs
@@ -162,7 +162,7 @@ pub async fn premium_remove(ctx: CommandContext) -> CommandResult {
     let transaction = db.transaction().await?;
 
     let guild_change = transaction
-        .prepare_cached("UPDATE guilds SET kind = $1, premium_owner = NULL WHERE guild_id = $2")
+        .prepare_cached("UPDATE guilds SET kind = $1, premium_owner = NULL, auto_detection = false WHERE guild_id = $2")
         .await?;
     transaction
         .execute(&guild_change, &[&GuildType::Free, &guild.guild_id])

--- a/rowifi/src/commands/premium/transfer.rs
+++ b/rowifi/src/commands/premium/transfer.rs
@@ -143,7 +143,7 @@ pub async fn premium_transfer(
     let transaction = db.transaction().await?;
 
     let guild_change = transaction
-        .prepare_cached("UPDATE guilds SET kind = $1, premium_owner = NULL WHERE guild_id = $2")
+        .prepare_cached("UPDATE guilds SET kind = $1, premium_owner = NULL, auto_detection = false WHERE guild_id = $2")
         .await?;
     for server in user.premium_servers {
         transaction
@@ -262,7 +262,7 @@ pub async fn premium_untransfer(ctx: CommandContext) -> CommandResult {
     let transaction = db.transaction().await?;
 
     let guild_change = transaction
-        .prepare_cached("UPDATE guilds SET kind = $1 WHERE guild_id = $2")
+        .prepare_cached("UPDATE guilds SET kind = $1, premium_owner = NULL, auto_detection = false WHERE guild_id = $2")
         .await?;
     for server in transfer_to_user.premium_servers {
         transaction

--- a/rowifi/src/commands/premium/transfer.rs
+++ b/rowifi/src/commands/premium/transfer.rs
@@ -38,12 +38,24 @@ pub async fn premium_transfer(
         }
     };
 
+    if user.flags.contains(UserFlags::STAFF) {
+        let embed = EmbedBuilder::new()
+            .default_data()
+            .color(Color::Red as u32)
+            .title("Premium Transfer Failed")
+            .description("You may not transfer a Staff Tier Premium.")
+            .build()
+            .unwrap();
+        ctx.respond().embeds(&[embed])?.exec().await?;
+        return Ok(());
+    }
+
     if user.transferred_to.is_some() {
         let embed = EmbedBuilder::new()
             .default_data()
             .color(Color::Red as u32)
             .title("Premium Transfer Failed")
-            .description("You have already transferred a premium to someone else. You may not transfer it again.")
+            .description("You have already transferred premium to someone else. You may not transfer it again.")
             .build()
             .unwrap();
         ctx.respond().embeds(&[embed])?.exec().await?;
@@ -131,7 +143,7 @@ pub async fn premium_transfer(
     let transaction = db.transaction().await?;
 
     let guild_change = transaction
-        .prepare_cached("UPDATE guilds SET kind = $1 WHERE guild_id = $2")
+        .prepare_cached("UPDATE guilds SET kind = $1, premium_owner = NULL WHERE guild_id = $2")
         .await?;
     for server in user.premium_servers {
         transaction

--- a/rowifi/src/commands/settings/mod.rs
+++ b/rowifi/src/commands/settings/mod.rs
@@ -15,7 +15,7 @@ use admin::{admin_add, admin_remove, admin_set, admin_view};
 use bypass::{bypass_add, bypass_remove, bypass_set, bypass_view};
 use functional::functional;
 use log::log_channel;
-use misc::{blacklist_action, settings_prefix, toggle_commands};
+use misc::{blacklist_action, settings_prefix, toggle_ad, toggle_commands};
 use nickname_bypass::{
     nickname_bypass_add, nickname_bypass_remove, nickname_bypass_set, nickname_bypass_view,
 };
@@ -245,6 +245,12 @@ pub fn settings_config(cmds: &mut Vec<Command>) {
         .description("Command to change the RoWifi permissions of a discord role")
         .handler(functional);
 
+    let toggle_ad_cmd = Command::builder()
+        .level(RoLevel::Admin)
+        .names(&["auto-detection", "ad"])
+        .description("Command to toggle the auto detection setting of the server")
+        .handler(toggle_ad);
+
     let settings_cmd = Command::builder()
         .level(RoLevel::Admin)
         .names(&["settings", "setting"])
@@ -263,6 +269,7 @@ pub fn settings_config(cmds: &mut Vec<Command>) {
         .sub_command(settings_nickname_bypass_cmd)
         .sub_command(log_channel_cmd)
         .sub_command(functional_cmd)
+        .sub_command(toggle_ad_cmd)
         .handler(settings_view);
     cmds.push(settings_cmd);
 }


### PR DESCRIPTION
Adds `settings auto-detection` to allow toggling of the auto detection. It doesn't cancel the auto detection of the current cycle.