### PR TITLE
Fix execution of `/backup restore`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1491,7 +1491,7 @@ dependencies = [
 
 [[package]]
 name = "rowifi"
-version = "3.2.1"
+version = "3.2.2"
 dependencies = [
  "base64",
  "chrono",

--- a/rowifi/Cargo.toml
+++ b/rowifi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rowifi"
-version = "3.2.1"
+version = "3.2.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/rowifi/src/commands/backup/restore.rs
+++ b/rowifi/src/commands/backup/restore.rs
@@ -43,7 +43,7 @@ pub async fn backup_restore(ctx: CommandContext, args: BackupArguments) -> Comma
         .bot
         .database
         .query_opt::<GuildBackup>(
-            "SELECT * FROM backup WHERE discord_id = $1 AND name = $2",
+            "SELECT * FROM backups WHERE discord_id = $1 AND name = $2",
             &[&(ctx.author.id.get() as i64), &name],
         )
         .await?
@@ -195,15 +195,21 @@ pub async fn backup_restore(ctx: CommandContext, args: BackupArguments) -> Comma
     let mut db = ctx.bot.database.get().await?;
     let transaction = db.transaction().await?;
 
-    let delete_guild = transaction
-        .prepare_cached("DELETE FROM guilds WHERE guild_id = $1")
-        .await?;
+    let insert_guild = transaction.prepare_cached("UPDATE guilds SET kind = $2, command_prefix = $3, verification_roles = $4, verified_roles = $5, blacklists = $6, blacklist_action = $7, update_on_join = $8 WHERE guild_id = $1").await?;
     transaction
-        .execute(&delete_guild, &[&guild.guild_id])
-        .await?;
-    let insert_guild = transaction.prepare_cached("INSERT INTO guilds(guild_id, kind, command_prefix, verification_roles, verified_roles, blacklists, blacklist_action, update_on_join) VALUES($1, $2, $3, $4, $5, $6, $7, $8)").await?;
-    transaction
-        .execute(&insert_guild, &[&guild.guild_id])
+        .execute(
+            &insert_guild,
+            &[
+                &guild.guild_id,
+                &guild.kind,
+                &guild.command_prefix,
+                &guild.verification_roles,
+                &guild.verified_roles,
+                &guild.blacklists,
+                &guild.blacklist_action,
+                &guild.update_on_join,
+            ],
+        )
         .await?;
 
     let delete_binds = transaction

--- a/rowifi/src/commands/backup/restore.rs
+++ b/rowifi/src/commands/backup/restore.rs
@@ -195,19 +195,27 @@ pub async fn backup_restore(ctx: CommandContext, args: BackupArguments) -> Comma
     let mut db = ctx.bot.database.get().await?;
     let transaction = db.transaction().await?;
 
-    let insert_guild = transaction.prepare_cached("UPDATE guilds SET kind = $2, command_prefix = $3, verification_roles = $4, verified_roles = $5, blacklists = $6, blacklist_action = $7, update_on_join = $8 WHERE guild_id = $1").await?;
+    let insert_guild = transaction.prepare_cached("UPDATE guilds SET kind = $2, premium_owner = $3, command_prefix = $4, verification_roles = $5, verified_roles = $6, blacklists = $7, disabled_channels = $8, registered_groups = $9, auto_detection = $10, blacklist_action = $11, update_on_join = $12, admin_roles = $13, trainer_roles = $14, bypass_roles = $15, nickname_bypass_roles = $16 WHERE guild_id = $1").await?;
     transaction
         .execute(
             &insert_guild,
             &[
                 &guild.guild_id,
                 &guild.kind,
+                &guild.premium_owner,
                 &guild.command_prefix,
                 &guild.verification_roles,
                 &guild.verified_roles,
                 &guild.blacklists,
+                &guild.disabled_channels,
+                &guild.registered_groups,
+                &guild.auto_detection,
                 &guild.blacklist_action,
                 &guild.update_on_join,
+                &guild.admin_roles,
+                &guild.trainer_roles,
+                &guild.bypass_roles,
+                &guild.nickname_bypass_roles
             ],
         )
         .await?;

--- a/rowifi/src/commands/backup/restore.rs
+++ b/rowifi/src/commands/backup/restore.rs
@@ -215,7 +215,7 @@ pub async fn backup_restore(ctx: CommandContext, args: BackupArguments) -> Comma
                 &guild.admin_roles,
                 &guild.trainer_roles,
                 &guild.bypass_roles,
-                &guild.nickname_bypass_roles
+                &guild.nickname_bypass_roles,
             ],
         )
         .await?;


### PR DESCRIPTION
There were 2 bugs in the command:
- Incorrect table name
- `INSERT` query for the guild had the incorrect number of parameters.